### PR TITLE
Paperify the iron-autogrow-textarea

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "polymer": "Polymer/polymer#v0.9.0-rc.1",
     "iron-input": "PolymerElements/iron-input#^0.9.0",
-    "paper-styles": "PolymerElements/paper-styles#^0.9.0"
+    "paper-styles": "PolymerElements/paper-styles#^0.9.0",
+    "iron-autogrow-textarea": "PolymerElements/iron-autogrow-textarea#^0.9.0"
   },
   "devDependencies": {
     "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^0.9.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,6 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../paper-input-container.html">
   <link rel="import" href="../paper-input-error.html">
   <link rel="import" href="../paper-input-char-counter.html">
+  <link rel="import" href="../paper-autogrow-textarea.html">
   <link rel="import" href="../../iron-input/iron-input.html">
 
   <link rel="stylesheet" href="../../paper-styles/demo.css">
@@ -40,10 +41,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <paper-input label="disabled" disabled></paper-input>
 
-    <paper-input-container>
-      <label>label</label>
-      <textarea></textarea>
-    </paper-input-container>
+    <paper-autogrow-textarea no-label-float label="textarea label (no-label-float)"></paper-autogrow-textarea>
+
+    <paper-autogrow-textarea label="textarea label"></paper-autogrow-textarea>
 
   </section>
 
@@ -57,6 +57,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <paper-input label="required input" auto-validate required error-message="input required!"></paper-input>
 
+    <paper-autogrow-textarea label="textarea, required input" auto-validate required error-message="input required!"></paper-autogrow-textarea>
+
   </section>
 
   <section>
@@ -66,6 +68,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <paper-input label="label" char-counter></paper-input>
 
     <paper-input label="at most 5 characters" char-counter maxlength="5"></paper-input>
+
+    <paper-autogrow-textarea label="textarea" char-counter></paper-autogrow-textarea>
+
+    <paper-autogrow-textarea label="textarea, at most 10 characters" char-counter maxlength="10"></paper-autogrow-textarea>
 
   </section>
 

--- a/paper-autogrow-textarea.html
+++ b/paper-autogrow-textarea.html
@@ -1,0 +1,64 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-autogrow-textarea/iron-autogrow-textarea.html">
+<link rel="import" href="paper-input-behavior.html">
+<link rel="import" href="paper-input-container.html">
+<link rel="import" href="paper-input-error.html">
+<link rel="import" href="paper-input-char-counter.html">
+
+<!--
+`<paper-autogrow-textarea>` is a text area that grows as text is entered.
+-->
+
+<dom-module id="paper-autogrow-textarea">
+  <template>
+
+    <paper-input-container no-label-float$="[[noLabelFloat]]" auto-validate$="[[autoValidate]]" attr-for-value="bindValue" disabled$="[[disabled]]">
+
+      <template is="dom-if" if="[[label]]">
+        <label>[[label]]</label>
+      </template>
+
+      <iron-autogrow-textarea bind-value="{{value}}">
+        <textarea id="input" required$="[[required]]" maxlength$="[[maxlength]]"></textarea>
+      </iron-autogrow-textarea>
+
+      <template is="dom-if" if="[[errorMessage]]">
+        <paper-input-error>[[errorMessage]]</paper-input-error>
+      </template>
+
+      <template is="dom-if" if="[[charCounter]]">
+        <paper-input-char-counter></paper-input-char-counter>
+      </template>
+
+    </paper-input-container>
+
+  </template>
+
+</dom-module>
+
+<script>
+
+(function() {
+
+  Polymer({
+
+    is: 'paper-autogrow-textarea',
+
+    behaviors: [
+      Polymer.PaperInputBehavior
+    ]
+
+  })
+
+})();
+
+</script>

--- a/paper-input-char-counter.html
+++ b/paper-input-char-counter.html
@@ -81,7 +81,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _computeCharCounter: function(inputElement,value) {
-      var str = value.length;
+      // Account for the textarea's new lines.
+      var str = value.replace(/(\r\n|\n|\r)/g, '--').length;
+
       if (inputElement.hasAttribute('maxlength')) {
         str += '/' + inputElement.maxLength;
       }

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -141,6 +141,7 @@ For example:
 
     .input-content ::content input,
     .input-content ::content textarea,
+    .input-content ::content iron-autogrow-textarea,
     .input-content ::content .paper-input-input {
       position: relative; /* to make a stacking context */
       outline: none;
@@ -150,7 +151,8 @@ For example:
     }
 
     .input-content ::content input,
-    .input-content ::content textarea {
+    .input-content ::content textarea,
+    .input-content ::content iron-autogrow-textarea {
       padding: 0;
       width: 100%;
       background: transparent;

--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     WCT.loadSuites([
       'paper-input.html',
+      'paper-autogrow-textarea.html',
       'paper-input-container.html',
       'paper-input-error.html',
       'paper-input-char-counter.html'

--- a/test/paper-autogrow-textarea.html
+++ b/test/paper-autogrow-textarea.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+  <title>paper-autogrow-textarea tests</title>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+  <script src="../../iron-test-helpers/test-helpers.js"></script>
+
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../paper-autogrow-textarea.html">
+
+</head>
+<body>
+
+  <test-fixture id="basic">
+    <template>
+      <paper-autogrow-textarea></paper-autogrow-textarea>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="required">
+    <template>
+      <paper-autogrow-textarea auto-validate required error-message="error"></paper-autogrow-textarea>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="char-counter">
+    <template>
+      <paper-autogrow-textarea char-counter value="foobar"></paper-autogrow-textarea>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    suite('basic', function() {
+
+      test('setting value sets the input value', function() {
+        var input = fixture('basic');
+        input.value = 'foobar';
+        assert.equal(input.inputElement.value, input.value, 'inputElement.value equals input.value');
+      });
+
+      test('empty required input shows error', function() {
+        var input = fixture('required');
+        forceXIfStamp(input);
+        var error = Polymer.dom(input.root).querySelector('paper-input-error');
+        assert.ok(error, 'paper-input-error exists');
+        assert.notEqual(getComputedStyle(error).display, 'none', 'error is not display:none');
+      });
+
+      test('character counter is displayed', function() {
+        var input = fixture('char-counter');
+        forceXIfStamp(input);
+        var counter = Polymer.dom(input.root).querySelector('paper-input-char-counter')
+        assert.ok(counter, 'paper-input-char-counter exists');
+        assert.equal(counter.charCounter, input.value.length, 'character counter shows the value length');
+      });
+
+      test('character counter counts new lines correctly', function() {
+        var input = fixture('char-counter');
+        input.value = 'foo\nbar';
+        forceXIfStamp(input);
+
+        var counter = Polymer.dom(input.root).querySelector('paper-input-char-counter')
+        assert.ok(counter, 'paper-input-char-counter exists');
+
+        // A new line counts as two characters.
+        assert.equal(counter.charCounter, input.value.length + 1, 'character counter shows the value length');
+      });
+
+    });
+
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
This is basically a copy cat of `paper-input` with an `iron-autogrow-textarea` instead of an `iron-input`. 
PTAL.

/cc @cdata