### PR TITLE
support for custom validators and inputs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^0.9.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^0.9.0",
+    "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^0.9.0",
     "test-fixture": "PolymerElements/test-fixture#^0.9.0",
     "web-component-tester": "Polymer/web-component-tester#^2.2.3",
     "webcomponentsjs": "Polymer/webcomponentsjs#^0.6.0"

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,8 +23,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../paper-input-container.html">
   <link rel="import" href="../paper-input-error.html">
   <link rel="import" href="../paper-input-char-counter.html">
-  <link rel="import" href="../paper-autogrow-textarea.html">
+  <link rel="import" href="../paper-textarea.html">
   <link rel="import" href="../../iron-input/iron-input.html">
+  <link rel="import" href="ssn-input.html">
 
   <link rel="stylesheet" href="../../paper-styles/demo.css">
 
@@ -41,9 +42,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <paper-input label="disabled" disabled></paper-input>
 
-    <paper-autogrow-textarea no-label-float label="textarea label (no-label-float)"></paper-autogrow-textarea>
+    <paper-textarea no-label-float label="textarea label (no-label-float)"></paper-textarea>
 
-    <paper-autogrow-textarea label="textarea label"></paper-autogrow-textarea>
+    <paper-textarea label="textarea label"></paper-textarea>
 
   </section>
 
@@ -57,7 +58,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <paper-input label="required input" auto-validate required error-message="input required!"></paper-input>
 
-    <paper-autogrow-textarea label="textarea, required input" auto-validate required error-message="input required!"></paper-autogrow-textarea>
+    <paper-textarea label="textarea, required input" auto-validate required error-message="input required!"></paper-textarea>
 
   </section>
 
@@ -69,9 +70,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <paper-input label="at most 5 characters" char-counter maxlength="5"></paper-input>
 
-    <paper-autogrow-textarea label="textarea" char-counter></paper-autogrow-textarea>
+    <paper-textarea label="textarea" char-counter></paper-textarea>
 
-    <paper-autogrow-textarea label="textarea, at most 10 characters" char-counter maxlength="10"></paper-autogrow-textarea>
+    <paper-textarea label="textarea, at most 10 characters" char-counter maxlength="10"></paper-textarea>
+
+  </section>
+
+  <section>
+
+    <div>Complex Inputs</div>
+
+    <template is="dom-bind">
+
+      <paper-input-container always-float-label auto-validate attr-for-value="value">
+        <label>Social Security Number</label>
+        <ssn-input class="paper-input-input"></ssn-input>
+        <paper-input-error>SSN invalid!</paper-input-error>
+      </paper-input-container>
+
+    </template>
 
   </section>
 

--- a/demo/ssn-input.html
+++ b/demo/ssn-input.html
@@ -1,0 +1,90 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-input/iron-input.html">
+<link rel="import" href="ssn-validator.html">
+
+<dom-module id="ssn-input">
+
+  <style>
+
+    :host {
+      display: inline-block;
+    }
+
+    input[is="iron-input"] {
+      width: auto;
+      text-align: center;
+    }
+
+  </style>
+
+  <template>
+
+    <ssn-validator></ssn-validator>
+
+    <input is="iron-input" maxlength="3" bind-value="{{_ssn1}}" size="3">
+    -
+    <input is="iron-input" maxlength="2" bind-value="{{_ssn2}}" size="2">
+    -
+    <input is="iron-input" maxlength="4" bind-value="{{_ssn3}}" size="4">
+
+  </template>
+
+</dom-module>
+
+<script>
+(function() {
+
+  Polymer({
+
+    is: 'ssn-input',
+
+    behaviors: [
+      Polymer.IronValidatableBehavior
+    ],
+
+    properties: {
+
+      value: {
+        notify: true,
+        type: String
+      },
+
+      _ssn1: {
+        type: String
+      },
+
+      _ssn2: {
+        type: String
+      },
+
+      _ssn3: {
+        type: String
+      },
+
+      validator: {
+        type: String,
+        value: 'ssn-validator'
+      }
+
+    },
+
+    observers: [
+      '_computeValue(_ssn1,_ssn2,_ssn3)'
+    ],
+
+    _computeValue: function(ssn1, ssn2, ssn3) {
+      this.value = ssn1.trim() + '-' + ssn2.trim() + '-' + ssn3.trim();
+    }
+
+  })
+})();
+</script>

--- a/demo/ssn-validator.html
+++ b/demo/ssn-validator.html
@@ -1,0 +1,31 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-validator-behavior/iron-validator-behavior.html">
+
+<script>
+
+  Polymer({
+
+    is: 'ssn-validator',
+
+    behaviors: [
+      Polymer.IronValidatorBehavior
+    ],
+
+    validate: function(value) {
+      // this regex validates incomplete ssn's (by design)
+      return !value || value.match(/[0-9]{0,3}-[0-9]{0,2}-[0-9]{0,4}/);
+    }
+
+  });
+
+</script>

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -110,6 +110,14 @@ Use `Polymer.PaperInputBehavior` to implement your own `<paper-input>`.
       },
 
       /**
+       * Set to true to always float the label.
+       */
+      alwaysFloatLabel: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
        * Set to true to auto-validate the input value.
        */
       autoValidate: {
@@ -147,6 +155,9 @@ Use `Polymer.PaperInputBehavior` to implement your own `<paper-input>`.
         type: String
       },
 
+      /**
+       * A placeholder string in addition to the label. If this is set, the label will always float.
+       */
       placeholder: {
         type: String
       },
@@ -167,6 +178,10 @@ Use `Polymer.PaperInputBehavior` to implement your own `<paper-input>`.
      */
     get inputElement() {
       return this.$.input;
+    },
+
+    _computeAlwaysFloatLabel: function(alwaysFloatLabel, placeholder) {
+      return placeholder || alwaysFloatLabel;
     }
 
   };

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -43,6 +43,14 @@ Use `Polymer.PaperInputBehavior` to implement your own `<paper-input>`.
       },
 
       /**
+       * Returns true if the value is invalid.
+       */
+      invalid: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
        * Set to true to prevent the user from entering invalid input.
        */
       preventInvalidInput: {
@@ -107,6 +115,49 @@ Use `Polymer.PaperInputBehavior` to implement your own `<paper-input>`.
       autoValidate: {
         type: Boolean,
         value: false
+      },
+
+      /**
+       * Name of the validator to use.
+       */
+      validator: {
+        type: String
+      },
+
+      // HTMLInputElement attributes for binding if needed
+
+      autocomplete: {
+        type: String,
+        value: 'off'
+      },
+
+      autofocus: {
+        type: Boolean
+      },
+
+      inputmode: {
+        type: String
+      },
+
+      minlength: {
+        type: Number
+      },
+
+      name: {
+        type: String
+      },
+
+      placeholder: {
+        type: String
+      },
+
+      readonly: {
+        type: Boolean,
+        value: false
+      },
+
+      size: {
+        type: Number
       }
 
     },

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -188,16 +188,16 @@ For example:
       <div class="floated-label-placeholder">&nbsp;</div>
     </template>
 
-    <div class$="[[_computeInputContentClass(noLabelFloat,focused,_inputHasContent,_inputIsInvalid)]]">
+    <div class$="[[_computeInputContentClass(noLabelFloat,alwaysFloatLabel,focused,invalid,_inputHasContent)]]">
       <content select=":not([add-on])"></content>
     </div>
 
-    <div class$="[[_computeUnderlineClass(focused,_inputIsInvalid)]]">
+    <div class$="[[_computeUnderlineClass(focused,invalid)]]">
       <div class="unfocused-line fit"></div>
       <div class="focused-line fit"></div>
     </div>
 
-    <div class$="[[_computeAddOnContentClass(focused,_inputIsInvalid)]]">
+    <div class$="[[_computeAddOnContentClass(focused,invalid)]]">
       <content id="addOnContent" select="[add-on]"></content>
     </div>
 
@@ -223,17 +223,33 @@ For example:
       },
 
       /**
+       * Set to true to always float the floating label.
+       */
+      alwaysFloatLabel: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
        * The attribute to listen for value changes on.
        */
       attrForValue: {
         type: String,
-        value: 'bind-value'
+        value: ''
       },
 
       /**
        * Set to true to auto-validate the input value.
        */
       autoValidate: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
+       * True if the input is invalid.
+       */
+      invalid: {
         type: Boolean,
         value: false
       },
@@ -259,11 +275,6 @@ For example:
         value: false
       },
 
-      _inputIsInvalid: {
-        type: Boolean,
-        value: false
-      },
-
       _inputSelector: {
         type: String,
         value: 'input,textarea,.paper-input-input'
@@ -283,6 +294,13 @@ For example:
         }
       },
 
+      _boundOnInput: {
+        type: Function,
+        value: function() {
+          this._onInput.bind(this)
+        }
+      },
+
       _boundValueChanged: {
         type: Function,
         value: function() {
@@ -293,8 +311,7 @@ For example:
     },
 
     listeners: {
-      'addon-attached': '_onAddonAttached',
-      'input': '_onInput'
+      'addon-attached': '_onAddonAttached'
     },
 
     get _valueChangedEvent() {
@@ -312,16 +329,20 @@ For example:
     ready: function() {
       this.addEventListener('focus', this._boundOnFocus, true);
       this.addEventListener('blur', this._boundOnBlur, true);
-      this.addEventListener(this._valueChangedEvent, this._boundValueChanged, true);
+      if (this.attrForValue) {
+        this._inputElement.addEventListener(this._valueChangedEvent, this._boundValueChanged);
+      } else {
+        this.addEventListener('input', this._onInput);
+      }
     },
 
     attached: function() {
-      this._handleInput(this._inputElement);
+      this._handleValue(this._inputElement);
     },
 
     _onAddonAttached: function(event) {
       this._addons.push(event.target);
-      this._handleInput(this._inputElement);
+      this._handleValue(this._inputElement);
     },
 
     _onFocus: function() {
@@ -333,16 +354,24 @@ For example:
     },
 
     _onInput: function(event) {
-      this._handleInput(event.target);
+      this._handleValue(event.target);
     },
 
     _onValueChanged: function(event) {
-      this._handleInput(event.target);
+      this._handleValue(event.target);
     },
 
-    _handleInput: function(inputElement) {
+    _handleValue: function(inputElement) {
       var value = inputElement[this._propertyForValue] || inputElement.value;
-      var valid = inputElement.checkValidity();
+
+      var valid;
+      if (inputElement.validate) {
+        valid = inputElement.validate(value);
+      } else if (inputElement.checkValidity) {
+        valid = inputElement.checkValidity();
+      } else {
+        valid = true;
+      }
 
       // type="number" hack needed because this.value is empty until it's valid
       if (value || inputElement.type === 'number' && !valid) {
@@ -352,7 +381,7 @@ For example:
       }
 
       if (this.autoValidate) {
-        this._inputIsInvalid = !valid;
+        this.invalid = !valid;
       }
 
       // notify add-ons
@@ -364,12 +393,12 @@ For example:
       }
     },
 
-    _computeInputContentClass: function(noLabelFloat, focused, _inputHasContent, _inputIsInvalid) {
+    _computeInputContentClass: function(noLabelFloat, alwaysFloatLabel, focused, invalid, _inputHasContent) {
       var cls = 'input-content';
       if (!noLabelFloat) {
-        if (_inputHasContent) {
+        if (alwaysFloatLabel || _inputHasContent) {
           cls += ' label-is-floating';
-          if (_inputIsInvalid) {
+          if (invalid) {
             cls += ' is-invalid';
           } else if (focused) {
             cls += " label-is-highlighted";
@@ -383,9 +412,9 @@ For example:
       return cls;
     },
 
-    _computeUnderlineClass: function(focused, _inputIsInvalid) {
+    _computeUnderlineClass: function(focused, invalid) {
       var cls = 'underline';
-      if (_inputIsInvalid) {
+      if (invalid) {
         cls += ' is-invalid';
       } else if (focused) {
         cls += ' is-highlighted'
@@ -393,9 +422,9 @@ For example:
       return cls;
     },
 
-    _computeAddOnContentClass: function(focused, _inputIsInvalid) {
+    _computeAddOnContentClass: function(focused, invalid) {
       var cls = 'add-on-content';
-      if (_inputIsInvalid) {
+      if (invalid) {
         cls += ' is-invalid';
       } else if (focused) {
         cls += ' is-highlighted'

--- a/paper-input.html
+++ b/paper-input.html
@@ -22,7 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <template>
 
-    <paper-input-container no-label-float$="[[noLabelFloat]]" auto-validate$="[[autoValidate]]" disabled$="[[disabled]]" attr-for-value="bind-value">
+    <paper-input-container no-label-float="[[noLabelFloat]]" always-float-label="[[_computeAlwaysFloatLabel(alwaysFloatLabel,placeholder)]]" auto-validate$="[[autoValidate]]" disabled$="[[disabled]]" attr-for-value="bind-value">
 
       <template is="dom-if" if="[[label]]">
         <label>[[label]]</label>

--- a/paper-input.html
+++ b/paper-input.html
@@ -22,13 +22,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <template>
 
-    <paper-input-container no-label-float$="[[noLabelFloat]]" auto-validate$="[[autoValidate]]" disabled$="[[disabled]]">
+    <paper-input-container no-label-float$="[[noLabelFloat]]" auto-validate$="[[autoValidate]]" disabled$="[[disabled]]" attr-for-value="bind-value">
 
       <template is="dom-if" if="[[label]]">
         <label>[[label]]</label>
       </template>
 
-      <input is="iron-input" id="input" bind-value="{{value}}" prevent-invalid-input="[[preventInvalidInput]]" type$="[[type]]" pattern$="[[pattern]]" maxlength$="[[maxlength]]" required$="[[required]]" disabled$="[[disabled]]">
+      <input is="iron-input" id="input" bind-value="{{value}}" invalid="{{invalid}}" prevent-invalid-input="[[preventInvalidInput]]" type$="[[type]]" pattern$="[[pattern]]" maxlength$="[[maxlength]]" required$="[[required]]" disabled$="[[disabled]]" autocomplete$="[[autocomplete]]" autofocus$="[[autofocus]]" inputmode$="[[inputmode]]" minlength$="[[minlength]]" name$="[[name]]" placeholder$="[[placeholder]]" readonly$="[[readonly]]" size$="[[size]]">
 
       <template is="dom-if" if="[[errorMessage]]">
         <paper-input-error>[[errorMessage]]</paper-input-error>

--- a/paper-input.html
+++ b/paper-input.html
@@ -28,7 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <label>[[label]]</label>
       </template>
 
-      <input is="iron-input" id="input" bind-value="{{value}}" invalid="{{invalid}}" prevent-invalid-input="[[preventInvalidInput]]" type$="[[type]]" pattern$="[[pattern]]" maxlength$="[[maxlength]]" required$="[[required]]" disabled$="[[disabled]]" autocomplete$="[[autocomplete]]" autofocus$="[[autofocus]]" inputmode$="[[inputmode]]" minlength$="[[minlength]]" name$="[[name]]" placeholder$="[[placeholder]]" readonly$="[[readonly]]" size$="[[size]]">
+      <input is="iron-input" id="input" bind-value="{{value}}" invalid="{{invalid}}" prevent-invalid-input="[[preventInvalidInput]]" type$="[[type]]" pattern$="[[pattern]]" maxlength$="[[maxlength]]" required$="[[required]]" disabled$="[[disabled]]" validator="[[validator]]" autocomplete$="[[autocomplete]]" autofocus$="[[autofocus]]" inputmode$="[[inputmode]]" minlength$="[[minlength]]" name$="[[name]]" placeholder$="[[placeholder]]" readonly$="[[readonly]]" size$="[[size]]">
 
       <template is="dom-if" if="[[errorMessage]]">
         <paper-input-error>[[errorMessage]]</paper-input-error>

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -15,13 +15,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="paper-input-char-counter.html">
 
 <!--
-`<paper-autogrow-textarea>` is a text area that grows as text is entered.
+`<paper-textarea>` is a text area that grows as text is entered.
 -->
 
-<dom-module id="paper-autogrow-textarea">
+<dom-module id="paper-textarea">
   <template>
 
-    <paper-input-container no-label-float$="[[noLabelFloat]]" auto-validate$="[[autoValidate]]" attr-for-value="bindValue" disabled$="[[disabled]]">
+    <paper-input-container no-label-float$="[[noLabelFloat]]" auto-validate$="[[autoValidate]]" disabled$="[[disabled]]">
 
       <template is="dom-if" if="[[label]]">
         <label>[[label]]</label>
@@ -51,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer({
 
-    is: 'paper-autogrow-textarea',
+    is: 'paper-textarea',
 
     behaviors: [
       Polymer.PaperInputBehavior

--- a/test/letters-only.html
+++ b/test/letters-only.html
@@ -1,0 +1,30 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-validator-behavior/iron-validator-behavior.html">
+
+<script>
+
+  Polymer({
+
+    is: 'letters-only',
+
+    behaviors: [
+      Polymer.IronValidatorBehavior
+    ],
+
+    validate: function(value) {
+      return !value || value.match(/^[a-zA-Z]*$/) !== null;
+    }
+
+  });
+
+</script>

--- a/test/paper-autogrow-textarea.html
+++ b/test/paper-autogrow-textarea.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
 
-  <title>paper-autogrow-textarea tests</title>
+  <title>paper-textarea tests</title>
 
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -24,26 +24,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../iron-test-helpers/test-helpers.js"></script>
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="../paper-autogrow-textarea.html">
+  <link rel="import" href="../paper-textarea.html">
 
 </head>
 <body>
 
   <test-fixture id="basic">
     <template>
-      <paper-autogrow-textarea></paper-autogrow-textarea>
+      <paper-textarea></paper-textarea>
     </template>
   </test-fixture>
 
   <test-fixture id="required">
     <template>
-      <paper-autogrow-textarea auto-validate required error-message="error"></paper-autogrow-textarea>
+      <paper-textarea auto-validate required error-message="error"></paper-textarea>
     </template>
   </test-fixture>
 
   <test-fixture id="char-counter">
     <template>
-      <paper-autogrow-textarea char-counter value="foobar"></paper-autogrow-textarea>
+      <paper-textarea char-counter value="foobar"></paper-textarea>
     </template>
   </test-fixture>
 

--- a/test/paper-input-container.html
+++ b/test/paper-input-container.html
@@ -24,6 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../../iron-input/iron-input.html">
   <link rel="import" href="../paper-input-container.html">
+  <link rel="import" href="letters-only.html">
 
 </head>
 <body>
@@ -55,11 +56,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="always-float">
+    <template>
+      <paper-input-container always-float-label>
+        <label id="l">label</label>
+        <input id="i" value="value">
+      </paper-input-container>
+    </template>
+  </test-fixture>
+
   <test-fixture id="auto-validate-numbers">
     <template>
-      <paper-input-container auto-validate>
+      <paper-input-container auto-validate attr-for-value="bind-value">
         <label id="l">label</label>
         <input is="iron-input" id="i" pattern="[0-9]*">
+      </paper-input-container>
+    </template>
+  </test-fixture>
+
+  <letters-only></letters-only>
+
+  <test-fixture id="auto-validate-validator">
+    <template>
+      <paper-input-container auto-validate attr-for-value="bind-value">
+        <label id="l">label</label>
+        <input is="iron-input" id="i" pattern="[0-9]*" validator="letters-only">
       </paper-input-container>
     </template>
   </test-fixture>
@@ -87,6 +108,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var container = fixture('no-float-has-value');
         assert.equal(getComputedStyle(container.querySelector('#l')).visibility, 'hidden', 'label has visibility:hidden');
       });
+
+      test('label is floated if always-float-label is true', function() {
+        var container = fixture('always-float');
+        assert.notEqual(getTransform(container.querySelector('#l')), 'none', 'label has transform');
+      })
 
     });
 
@@ -136,11 +162,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var line = Polymer.dom(container.root).querySelector('.focused-line');
         var color = getComputedStyle(label).color;
         line.addEventListener('transitionend', function() {
+          assert.isTrue(container.invalid, 'invalid is true');
           assert.notEqual(getComputedStyle(label).color, color, 'label is colored when input is invalid');
           assert.equal(getTransform(line), 'none', 'line is colored when input is invalid');
           done();
         });
         input.bindValue = 'foobar';
+      });
+
+      test('styled when the input is set to an invalid value with auto-validate, with validator', function(done) {
+        var container = fixture('auto-validate-validator');
+        var input = Polymer.dom(container).querySelector('#i');
+        var label = Polymer.dom(container).querySelector('#l');
+        var line = Polymer.dom(container.root).querySelector('.focused-line');
+        var color = getComputedStyle(label).color;
+        line.addEventListener('transitionend', function() {
+          assert.isTrue(container.invalid, 'invalid is true');
+          assert.notEqual(getComputedStyle(label).color, color, 'label is colored when input is invalid');
+          assert.equal(getTransform(line), 'none', 'line is colored when input is invalid');
+          done();
+        });
+        input.bindValue = '123123';
       });
 
     });

--- a/test/paper-input-error.html
+++ b/test/paper-input-error.html
@@ -31,7 +31,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="auto-validate-numbers">
     <template>
-      <paper-input-container auto-validate>
+      <paper-input-container auto-validate attr-for-value="bind-value">
         <label id="l">label</label>
         <input is="iron-input" id="i" pattern="[0-9]*">
         <paper-input-error id="e">error</paper-input-error>

--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -25,6 +25,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../paper-input.html">
+  <link rel="import" href="letters-only.html">
 
 </head>
 <body>
@@ -56,6 +57,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="placeholder">
     <template>
       <paper-input label="foo" placeholder="bar"></paper-input>
+    </template>
+  </test-fixture>
+
+  <letters-only></letters-only>
+
+  <test-fixture id="validator">
+    <template>
+      <paper-input value="123123" validator="letters-only" auto-validate></paper-input>
     </template>
   </test-fixture>
 
@@ -99,6 +108,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var counter = Polymer.dom(input.root).querySelector('paper-input-char-counter')
         assert.ok(counter, 'paper-input-char-counter exists');
         assert.equal(counter.charCounter, input.value.length, 'character counter shows the value length');
+      });
+
+      test('validator is used', function() {
+        var input = fixture('validator');
+        assert.ok(input.inputElement.invalid, 'input is invalid');
       });
 
     });

--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -53,6 +53,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="placeholder">
+    <template>
+      <paper-input label="foo" placeholder="bar"></paper-input>
+    </template>
+  </test-fixture>
+
   <script>
 
     suite('basic', function() {
@@ -61,6 +67,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var input = fixture('basic');
         input.value = 'foobar';
         assert.equal(input.inputElement.value, input.value, 'inputElement.value equals input.value');
+      });
+
+      test('placeholder does not overlap label', function() {
+        var input = fixture('placeholder');
+        assert.equal(input.inputElement.placeholder, input.placeholder, 'inputElement.placeholder equals input.placeholder');
+        assert.equal(input.noLabelFloat, false);
+        var floatingLabel = input.querySelector('.label-is-floating');
+        assert.ok(floatingLabel);
       });
 
       test('error message is displayed', function() {


### PR DESCRIPTION
Enables using a custom input in a paper-input-container. Either
provide attr-for-value to observe input value changes for validation
and label floating, or if unset the `input` event is used. See demo
for an example.

Also enables iron-validator-behavior support. The validator takes
precedence over constraints, if provided.

Bind to more HTMLInputElement attributes.

Renamed paper-autogrow-textarea to paper-textarea to be more
consistent with paper-textarea.

@cdata @notwaldorf PTAL