### PR TITLE
allow manual validation

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -66,6 +66,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <section>
 
+    <div>Manual Validation</div>
+
+    <paper-input id="inputForValidation" required label="only type letters" pattern="[a-zA-Z]*" error-message="letters only, required input!"></paper-input>
+    <br>
+    <button onclick="validate()">Validate!</button>
+
+  </section>
+
+  <section>
+
     <div>Character Counter</div>
 
     <paper-input label="label" char-counter></paper-input>
@@ -94,4 +104,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   </section>
 
+  <script>
+    function validate() {
+      document.getElementById('inputForValidation').validate();
+    }
+  </script>
 </body>
+</html>

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -180,6 +180,13 @@ Use `Polymer.PaperInputBehavior` to implement your own `<paper-input>`.
       return this.$.input;
     },
 
+    /**
+     * Validates the input element and sets an error style if needed.
+     */
+     validate:function () {
+       return this.inputElement.validate();
+     },
+
     _computeAlwaysFloatLabel: function(alwaysFloatLabel, placeholder) {
       return placeholder || alwaysFloatLabel;
     }

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -311,7 +311,8 @@ For example:
     },
 
     listeners: {
-      'addon-attached': '_onAddonAttached'
+      'addon-attached': '_onAddonAttached',
+      'iron-input-validate': '_onInputValidityChanged'
     },
 
     get _valueChangedEvent() {
@@ -365,10 +366,13 @@ For example:
       var value = inputElement[this._propertyForValue] || inputElement.value;
 
       var valid;
-      if (inputElement.validate) {
-        valid = inputElement.validate(value);
-      } else if (inputElement.checkValidity) {
-        valid = inputElement.checkValidity();
+
+      if (this.autoValidate) {
+        if (inputElement.validate) {
+          valid = inputElement.validate(value);
+        } else {
+          valid = inputElement.checkValidity();
+        }
       } else {
         valid = true;
       }
@@ -380,16 +384,21 @@ For example:
         this._inputHasContent = false;
       }
 
-      if (this.autoValidate) {
-        this.invalid = !valid;
-      }
-
       // notify add-ons
       for (var addon, i = 0; addon = this._addons[i]; i++) {
         // need to set all of these, or call method... thanks input type="number"!
         addon.inputElement = inputElement;
         addon.value = value;
         addon.invalid = !valid;
+      }
+    },
+
+    _onInputValidityChanged: function() {
+      this.invalid = this._inputElement.invalid;
+
+      // notify add-ons
+      for (var addon, i = 0; addon = this._addons[i]; i++) {
+        addon.invalid = this.invalid;
       }
     },
 

--- a/test/paper-input-container.html
+++ b/test/paper-input-container.html
@@ -74,6 +74,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="manual-validate-numbers">
+    <template>
+      <paper-input-container attr-for-value="bind-value">
+        <label id="l">label</label>
+        <input is="iron-input" id="i" pattern="[0-9]*">
+      </paper-input-container>
+    </template>
+  </test-fixture>
+
   <letters-only></letters-only>
 
   <test-fixture id="auto-validate-validator">
@@ -198,6 +207,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var container = fixture('auto-validate-validator-has-invalid-value');
         assert.isTrue(container.invalid, 'invalid is true');
         assert.isTrue(Polymer.dom(container.root).querySelector('.underline').classList.contains('is-invalid'), 'underline has is-invalid class');
+      });
+
+      test('styled when the input is set to an invalid value with manual validation', function(done) {
+        var container = fixture('manual-validate-numbers');
+        var input = Polymer.dom(container).querySelector('#i');
+        var label = Polymer.dom(container).querySelector('#l');
+        var line = Polymer.dom(container.root).querySelector('.focused-line');
+        var color = getComputedStyle(label).color;
+        line.addEventListener('transitionend', function() {
+          assert.isTrue(container.invalid, 'invalid is true');
+          assert.notEqual(getComputedStyle(label).color, color, 'label is colored when input is invalid');
+          assert.equal(getTransform(line), 'none', 'line is colored when input is invalid');
+          done();
+        });
+        input.bindValue = 'foobar';
+        input.validate();
       });
 
     });


### PR DESCRIPTION
Added a `validate()` function to the behaviour, and refactored the `paper-input-container` to get notified (and care) when the contained `iron-input`'s validity changes. PTAL.

Needs https://github.com/PolymerElements/iron-input/pull/13 to work.