### PR TITLE
fix native input's box-shadow

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -145,6 +145,7 @@ For example:
     .input-content ::content .paper-input-input {
       position: relative; /* to make a stacking context */
       outline: none;
+      box-shadow: none;
       color: var(--paper-input-container-input-color, --primary-text-color);
 
       @apply(--paper-input-container-floating-label-font);


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-input/issues/28

On Firefox, because CSS, an invalid `iron-input` has a box-shadow and shows up with a red box around it (see issue). 

After the fix, it looks like the paper-input we know and love
![screen shot 2015-05-18 at 9 54 46 pm](https://cloud.githubusercontent.com/assets/1369170/7695710/8faf6d30-fda8-11e4-9a4d-def75cca2634.png)