### PR TITLE
Set placeholder default color to `--secondary-text-color`

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -46,6 +46,22 @@ style this element.
       display: block;
     }
 
+    input::-webkit-input-placeholder {
+      color: var(--paper-input-container-color, --secondary-text-color);
+    }
+
+    input:-moz-placeholder {
+      color: var(--paper-input-container-color, --secondary-text-color);
+    }
+
+    input::-moz-placeholder {
+      color: var(--paper-input-container-color, --secondary-text-color);
+    }
+
+    input:-ms-input-placeholder {
+      color: var(--paper-input-container-color, --secondary-text-color);
+    }
+
   </style>
 
   <template>


### PR DESCRIPTION
As discussed in https://github.com/PolymerElements/paper-input/issues/5,  the native `placeholder` color should be default to `--secondary-text-color`.  

**Note:**  there're a lot of rules here, I tried combining all the selectors in a single rule, but it stopped working. I think it broke something.

cc @cdata  