### PR TITLE
fix issue #60

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -286,6 +286,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         label.id = labelledBy;
       }
       this._ariaLabelledBy = labelledBy;
+    },
+
+    focus: function () {
+      this.$.input.focus();
     }
 
   };


### PR DESCRIPTION
this i a fix for issue #60.
With this fix you can do document.querySelector('#id-of-pape-rinput').focus();