### PR TITLE
add formatting helper

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -264,9 +264,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * Validates the input element and sets an error style if needed.
      */
-     validate: function () {
+     validate: function() {
        return this.inputElement.validate();
      },
+
+    /**
+     * Restores the cursor to its original position after updating the value.
+     * @param {String} newValue The value that should be saved.
+     */
+    updateValueAndPreserveCaret: function(newValue) {
+      // Not all elements might have selection, and even if they have the
+      // right properties, accessing them might throw an exception (like for
+      // <input type=number>)
+      try {
+        var start = this.inputElement.selectionStart;
+        this.value = newValue;
+
+        // The cursor automatically jumps to the end after re-setting the value,
+        // so restore it to its original position.
+        this.inputElement.selectionStart = start;
+        this.inputElement.selectionEnd = start;
+      } catch (e) {
+        // Just set the value and give up on the caret.
+        this.value = newValue;
+      }
+    },
 
     _computeAlwaysFloatLabel: function(alwaysFloatLabel, placeholder) {
       return placeholder || alwaysFloatLabel;

--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -127,6 +127,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.ok(input.inputElement.invalid, 'input is invalid');
       });
 
+      test('caret position is preserved', function() {
+        var input = fixture('basic');
+        var ironInput = Polymer.dom(input.root).querySelector('input[is="iron-input"]');
+        input.value = 'nananana';
+        ironInput.selectionStart = 2;
+        ironInput.selectionEnd = 2;
+
+        input.updateValueAndPreserveCaret('nanananabatman');
+
+        assert.equal(ironInput.selectionStart, 2, 'selectionStart is preserved');
+        assert.equal(ironInput.selectionEnd, 2, 'selectionEnd is preserved');
+      });
+
     });
 
     suite('a11y', function() {

--- a/test/paper-textarea.html
+++ b/test/paper-textarea.html
@@ -77,6 +77,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.notEqual(getComputedStyle(error).display, 'none', 'error is not display:none');
       });
 
+      test('caret position is preserved', function() {
+        var input = fixture('basic');
+        var ironTextarea = Polymer.dom(input.root).querySelector('iron-autogrow-textarea');
+        input.value = 'nananana';
+        ironTextarea.selectionStart = 2;
+        ironTextarea.selectionEnd = 2;
+
+        input.updateValueAndPreserveCaret('nanananabatman');
+
+        assert.equal(ironTextarea.selectionStart, 2, 'selectionStart is preserved');
+        assert.equal(ironTextarea.selectionEnd, 2, 'selectionEnd is preserved');
+      });
+
     });
 
     suite('a11y', function() {


### PR DESCRIPTION
Added a helper formatting method (came up during https://github.com/PolymerElements/gold-phone-input/pull/16) that updates the value imperatively and preserves the caret position.