### PR TITLE
Added support for HTML5 datalists

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -84,6 +84,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
+       * The datalist of the input (if any). This should match the id of an existing <datalist>. Bind this
+       * to the `<input is="iron-input">`'s `list` property.
+       */
+      list: {
+        type: String
+      },
+
+      /**
        * A pattern to validate the `input` with. Bind this to the `<input is="iron-input">`'s
        * `pattern` property.
        */

--- a/paper-input.html
+++ b/paper-input.html
@@ -90,7 +90,8 @@ style this element.
         name$="[[name]]"
         placeholder$="[[placeholder]]"
         readonly$="[[readonly]]"
-        size$="[[size]]">
+        size$="[[size]]"
+		list$="[[list]]">
 
       <template is="dom-if" if="[[errorMessage]]">
         <paper-input-error>[[errorMessage]]</paper-input-error>

--- a/paper-input.html
+++ b/paper-input.html
@@ -91,7 +91,7 @@ style this element.
         placeholder$="[[placeholder]]"
         readonly$="[[readonly]]"
         size$="[[size]]"
-		list$="[[list]]">
+        list$="[[list]]">
 
       <template is="dom-if" if="[[errorMessage]]">
         <paper-input-error>[[errorMessage]]</paper-input-error>


### PR DESCRIPTION
Persists a list id attribute to the <iron-input> element to support HTML5 datalists.