### PR TITLE
Added support for HTML datalist

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -84,6 +84,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
+       * The datalist of the input (if any). This should match the id of an existing <datalist>. Bind this
+       * to the `<input is="iron-input">`'s `list` property.
+       */
+      list: {
+        type: String
+      },
+
+      /**
        * A pattern to validate the `input` with. Bind this to the `<input is="iron-input">`'s
        * `pattern` property.
        */

--- a/paper-input.html
+++ b/paper-input.html
@@ -90,6 +90,7 @@ style this element.
         name$="[[name]]"
         placeholder$="[[placeholder]]"
         readonly$="[[readonly]]"
+        list$="[[list]]"
         size$="[[size]]">
 
       <template is="dom-if" if="[[errorMessage]]">


### PR DESCRIPTION
Added support for HTML datalists.  This pull persists a list property as an attribute to the <input is="iron-element"> element.