### PR TITLE
add autocapitalize/autocorrect ios safari attributes

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -230,6 +230,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         type: Number
       },
 
+      // Nonstandard attributes for binding if needed
+
+      /**
+       * Bind this to the `<input is="iron-input">`'s `autocapitalize` property.
+       */
+      autocapitalize: {
+        type: String,
+        value: 'none'
+      },
+
+      /**
+       * Bind this to the `<input is="iron-input">`'s `autocorrect` property.
+       */
+      autocorrect: {
+        type: String,
+        value: 'off'
+      },
+
       _ariaDescribedBy: {
         type: String,
         value: ''

--- a/paper-input.html
+++ b/paper-input.html
@@ -91,7 +91,9 @@ style this element.
         placeholder$="[[placeholder]]"
         readonly$="[[readonly]]"
         list$="[[list]]"
-        size$="[[size]]">
+        size$="[[size]]"
+        autocapitalize$="[[autocapitalize]]"
+        autocorrect$="[[autocorrect]]">
 
       <template is="dom-if" if="[[errorMessage]]">
         <paper-input-error>[[errorMessage]]</paper-input-error>

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -48,7 +48,8 @@ style this element.
         placeholder$="[[placeholder]]"
         readonly$="[[readonly]]"
         required$="[[required]]"
-        maxlength$="[[maxlength]]"></iron-autogrow-textarea>
+        maxlength$="[[maxlength]]"
+        autocapitalize$="[[autocapitalize]]"></iron-autogrow-textarea>
 
       <template is="dom-if" if="[[errorMessage]]">
         <paper-input-error>[[errorMessage]]</paper-input-error>


### PR DESCRIPTION
For https://github.com/PolymerElements/paper-input/issues/88 PTAL @notwaldorf 