### PR TITLE
don't duplicate registration to the iron-form

### DIFF
--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-autogrow-textarea/iron-autogrow-textarea.html">
-<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 <link rel="import" href="paper-input-behavior.html">
 <link rel="import" href="paper-input-container.html">
 <link rel="import" href="paper-input-error.html">
@@ -74,8 +73,7 @@ style this element.
     is: 'paper-textarea',
 
     behaviors: [
-      Polymer.PaperInputBehavior,
-      Polymer.IronFormElementBehavior
+      Polymer.PaperInputBehavior
     ],
 
     properties: {


### PR DESCRIPTION
Since the `iron-autogrow-textarea` now registers to be added to an `iron-form` (https://github.com/PolymerElements/iron-autogrow-textarea/pull/18), we don't need to also register in `paper-textarea`

PTAL @morethanreal 