### PR TITLE
use visibility instead of display for error

### DIFF
--- a/paper-input-error.html
+++ b/paper-input-error.html
@@ -35,8 +35,8 @@ Custom property | Description | Default
   <style>
 
     :host {
-      /* need to use display: none for role="alert" */
-      display: none;
+      display: inline-block;
+      visibility: hidden;
       float: left;
 
       color: var(--paper-input-container-invalid-color, --google-red-500);
@@ -46,7 +46,7 @@ Custom property | Description | Default
     }
 
     :host([invalid]) {
-      display: inline-block;
+      visibility: visible;
     };
 
   </style>
@@ -70,10 +70,6 @@ Custom property | Description | Default
     behaviors: [
       Polymer.PaperInputAddonBehavior
     ],
-
-    hostAttributes: {
-      'role': 'alert'
-    },
 
     properties: {
 

--- a/test/paper-input-error.html
+++ b/test/paper-input-error.html
@@ -52,9 +52,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var container = fixture('auto-validate-numbers');
         var input = Polymer.dom(container).querySelector('#i');
         var error = Polymer.dom(container).querySelector('#e');
-        assert.equal(getComputedStyle(error).display, 'none', 'error is display:none');
+        assert.equal(getComputedStyle(error).visibility, 'hidden', 'error is visibility:hidden');
         input.bindValue = 'foobar';
-        assert.notEqual(getComputedStyle(error).display, 'none', 'error is not display:none');
+        assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
       });
 
       test('error message add on is registered', function() {


### PR DESCRIPTION
Fixes #95. The error is no longer role="alert" which means
it does not announce, but it's ok for a11y because the input
still has invalid and aria-describedby.

PTAL @notwaldorf 