### PR TITLE
 set alwaysFloatLabel to true if browser has native formatter

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -271,18 +271,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
+      this._checkNativeFormatter()
+      this._updateAriaLabelledBy();
+    },
+    _checkNativeFormatter: function() {
       // set alwaysFloatLabel to true if browser has native formatter (input->type:date or input->type:time etc.)
       // TODO make value change silent
       var value = this.inputElement.value;
       this.inputElement.value = ' ';
       if (!this.inputElement.value) {
         this.alwaysFloatLabel = true;
-      } else {
-        this.inputElement.value = value;
       }
-      this._updateAriaLabelledBy();
+      this.inputElement.value = value;
     },
-
     _appendStringWithSpace: function(str, more) {
       if (str) {
         str = str + ' ' + more;

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -273,11 +273,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     attached: function() {
       // set alwaysFloatLabel to true if browser has native formatter (input->type:date or input->type:time etc.)
       // TODO make value change silent
+      var value = this.inputElement.value;
       this.inputElement.value = ' ';
       if (!this.inputElement.value) {
         this.alwaysFloatLabel = true;
       } else {
-        this.inputElement.value = '';
+        this.inputElement.value = value;
       }
       this._updateAriaLabelledBy();
     },

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -274,8 +274,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._checkNativeFormatter();
       this._updateAriaLabelledBy();
     },
+    // set alwaysFloatLabel to true if browser has native formatter (input->type:date or input->type:time etc.)
     _checkNativeFormatter: function() {
-      // set alwaysFloatLabel to true if browser has native formatter (input->type:date or input->type:time etc.)
+      // only check these types if the label has to be always floated.
       var checkTypes = ['number', 'time', 'date'];
       if (checkTypes.indexOf(this.inputElement.type) === -1) {
         return;

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -271,6 +271,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
+      // set alwaysFloatLabel to true if browser has native formatter (input->type:date or input->type:time etc.)
+      // TODO make value change silent
+      this.inputElement.value = ' ';
+      if (!this.inputElement.value) {
+        this.alwaysFloatLabel = true;
+      } else {
+        this.inputElement.value = '';
+      }
       this._updateAriaLabelledBy();
     },
 

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -278,6 +278,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // set alwaysFloatLabel to true if browser has native formatter (input->type:date or input->type:time etc.)
       // TODO make value change silent
       var value = this.inputElement.value;
+      // TODO catch chrome format warning
       this.inputElement.value = ' ';
       if (!this.inputElement.value) {
         this.alwaysFloatLabel = true;

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -271,7 +271,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
-      this._checkNativeFormatter()
+      this._checkNativeFormatter();
       this._updateAriaLabelledBy();
     },
     _checkNativeFormatter: function() {

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -276,6 +276,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
     _checkNativeFormatter: function() {
       // set alwaysFloatLabel to true if browser has native formatter (input->type:date or input->type:time etc.)
+      var checkTypes = ['number', 'time', 'date'];
+      if (checkTypes.indexOf(this.inputElement.type) === -1) {
+        return;
+      }
       // TODO make value change silent
       var value = this.inputElement.value;
       // TODO catch chrome format warning

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -205,6 +205,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
       box-shadow: none;
       padding: 0;
       width: 100%;
+      // set min height so it does not screw design up if inputs have formatter
+      min-height: 26px;
       background: transparent;
       border: none;
       color: var(--paper-input-container-input-color, --primary-text-color);

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -205,7 +205,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       box-shadow: none;
       padding: 0;
       width: 100%;
-      // set min height so it does not screw design up if inputs have formatter
+      /* set min height so it does not screw design up if inputs have formatter */
       min-height: 26px;
       background: transparent;
       border: none;

--- a/paper-input.html
+++ b/paper-input.html
@@ -17,21 +17,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <!--
 `<paper-input>` is a single-line text field with Material Design styling.
-
     <paper-input label="Input label"></paper-input>
-
 It may include an optional error message or character counter.
-
     <paper-input error-message="Invalid input!" label="Input label"></paper-input>
     <paper-input char-counter label="Input label"></paper-input>
-
+It can also include custom prefix or suffix elements, which are displayed
+before or after the text input itself. In order for an element to be
+considered as a prefix, it must have the `prefix` attribute (and similarly
+for `suffix`).
+    <paper-input label="total">
+      <div prefix>$</div>
+      <paper-icon-button suffix icon="clear"></paper-icon-button>
+    </paper-input>
 See `Polymer.PaperInputBehavior` for more API docs.
-
 ### Styling
-
 See `Polymer.PaperInputContainer` for a list of custom properties used to
 style this element.
-
 @group Paper Elements
 @element paper-input
 @hero hero.svg
@@ -39,34 +40,29 @@ style this element.
 -->
 
 <dom-module id="paper-input">
-
-  <style>
-
-    :host {
-      display: block;
-    }
-
-    input::-webkit-input-placeholder {
-      color: var(--paper-input-container-color, --secondary-text-color);
-    }
-
-    input:-moz-placeholder {
-      color: var(--paper-input-container-color, --secondary-text-color);
-    }
-
-    input::-moz-placeholder {
-      color: var(--paper-input-container-color, --secondary-text-color);
-    }
-
-    input:-ms-input-placeholder {
-      color: var(--paper-input-container-color, --secondary-text-color);
-    }
-
-  </style>
-
   <template>
 
+    <style>
+      :host {
+        display: block;
+      }
+      input::-webkit-input-placeholder {
+        color: var(--paper-input-container-color, --secondary-text-color);
+      }
+      input:-moz-placeholder {
+        color: var(--paper-input-container-color, --secondary-text-color);
+      }
+      input::-moz-placeholder {
+        color: var(--paper-input-container-color, --secondary-text-color);
+      }
+      input:-ms-input-placeholder {
+        color: var(--paper-input-container-color, --secondary-text-color);
+      }
+    </style>
+
     <paper-input-container no-label-float="[[noLabelFloat]]" always-float-label="[[_computeAlwaysFloatLabel(alwaysFloatLabel,placeholder)]]" auto-validate$="[[autoValidate]]" disabled$="[[disabled]]" invalid="[[invalid]]">
+
+      <content select="[prefix]"></content>
 
       <label hidden$="[[!label]]">[[label]]</label>
 
@@ -81,12 +77,14 @@ style this element.
         validator="[[validator]]"
         type$="[[type]]"
         pattern$="[[pattern]]"
-        maxlength$="[[maxlength]]"
         required$="[[required]]"
         autocomplete$="[[autocomplete]]"
         autofocus$="[[autofocus]]"
         inputmode$="[[inputmode]]"
         minlength$="[[minlength]]"
+        maxlength$="[[maxlength]]"
+        min$="[[min]]"
+        max$="[[max]]"
         step$="[[step]]"
         name$="[[name]]"
         placeholder$="[[placeholder]]"
@@ -94,7 +92,10 @@ style this element.
         list$="[[list]]"
         size$="[[size]]"
         autocapitalize$="[[autocapitalize]]"
-        autocorrect$="[[autocorrect]]">
+        autocorrect$="[[autocorrect]]"
+        on-change="_onChange">
+
+      <content select="[suffix]"></content>
 
       <template is="dom-if" if="[[errorMessage]]">
         <paper-input-error>[[errorMessage]]</paper-input-error>
@@ -107,25 +108,15 @@ style this element.
     </paper-input-container>
 
   </template>
-
 </dom-module>
 
 <script>
-
-(function() {
-
   Polymer({
-
     is: 'paper-input',
-
     behaviors: [
       Polymer.IronFormElementBehavior,
       Polymer.PaperInputBehavior,
       Polymer.IronControlState
     ]
-
-  })
-
-})();
-
+  });
 </script>

--- a/paper-input.html
+++ b/paper-input.html
@@ -87,6 +87,7 @@ style this element.
         autofocus$="[[autofocus]]"
         inputmode$="[[inputmode]]"
         minlength$="[[minlength]]"
+        step$="[[step]]"
         name$="[[name]]"
         placeholder$="[[placeholder]]"
         readonly$="[[readonly]]"


### PR DESCRIPTION
Check if browser has native formatter by trying to set value of inputElement. If it did not set it, it has a native formatter.
If it has, set alwaysFloatLabel to true to avoid label overlap with formatter.