### PR TITLE
label should always stick to the underline

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -169,6 +169,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
     .input-content {
       position: relative;
       @apply(--layout-horizontal);
+      @apply(--layout-end);
     }
 
     .input-content ::content label,


### PR DESCRIPTION
Otherwise suffixes/prefixes can push it up.

This doesn't affect normal inputs (sans any *-ixes), seeeeee:
<img width="322" alt="screen shot 2015-08-03 at 5 13 55 pm" src="https://cloud.githubusercontent.com/assets/1369170/9050529/77693b9c-3a03-11e5-8e2c-d35f2763edab.png">

Note that with or without this patch, a giant label looks terrible and floats below the line. Future-Monica should fix this in a separate PR. With magical text truncation. Or something:
<img width="342" alt="screen shot 2015-08-03 at 5 15 49 pm" src="https://cloud.githubusercontent.com/assets/1369170/9050530/817b408a-3a03-11e5-8f9c-8e5e206e6f5b.png">


/cc @morethanreal @cdata 