### PR TITLE
fix #138

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -521,7 +521,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
           }
           // The label might have a horizontal offset if a prefix element exists
           // which needs to be undone when displayed as a floating label.
-          if (this.$.prefix && label && label.offsetParent) {
+          if (this.$.prefix && label && label.offsetParent &&
+              Polymer.dom(this.$.prefix).getDistributedNodes().length > 0) {
            label.style.left = -label.offsetParent.offsetLeft + 'px';
           }
         } else {


### PR DESCRIPTION
Fixes #138.

Needed to check if there were any `prefix` content children, not just whether the node existed (which it always does)

@cdata PTAL