### PR TITLE
Add focus passthrough for inputElement

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -394,6 +394,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         label.id = labelledBy;
       }
       this._ariaLabelledBy = labelledBy;
+    },
+
+    focus: function() {
+      // Pass focus calls on to the inputEleemnt.
+      this.inputElement.focus();
     }
 
   };


### PR DESCRIPTION
Not sure if this is the best way to achieve this, I looked at the other behavior-* implementations for iron-input etc, and none seemed to encompass similar functionality except for ControlState maybe. So for now I included this in the paper-input-behaviors.

Fixes #129