### PR TITLE
Replace translate3d by translateY

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -192,8 +192,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
 
       .input-content.label-is-floating ::content label,
       .input-content.label-is-floating ::content .paper-input-label {
-        -webkit-transform: translate3d(0, -75%, 0) scale(0.75);
-        transform: translate3d(0, -75%, 0) scale(0.75);
+        -webkit-transform: translateY(-75%) scale(0.75);
+        transform: translateY(-75%) scale(0.75);
         -webkit-transform-origin: left top;
         transform-origin: left top;
         -webkit-transition: -webkit-transform 0.25s;


### PR DESCRIPTION
Hello,

My team is building a mobile webapp using polymer. We managed to achieve very good performance by carefully measure and optimize bottlenecks. One of them is the number of graphical layers/GPU memory/Compositing. We found that the paper inputs have unnecessary layers due to the use of translate3d.

Thanks