### PR TITLE
make type=search less terrible

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -59,6 +59,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <div class="vertical-section">
       <paper-input label="label"></paper-input>
 
+      <paper-input label="search" type="search" placeholder="type='search' should use placeholders instead of labels" autosave="test" results="5"></paper-input>
+
       <paper-input label="password" type="password"></paper-input>
 
       <paper-input no-label-float label="label (no-label-float)"></paper-input>

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -279,6 +279,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         value: 'off'
       },
 
+      /**
+       * Bind this to the `<input is="iron-input">`'s `autosave` property, used with type=search.
+       */
+      autosave: {
+        type: String
+      },
+
+      /**
+       * Bind this to the `<input is="iron-input">`'s `results` property, , used with type=search.
+       */
+      results: {
+        type: Number
+      },
+
       _ariaDescribedBy: {
         type: String,
         value: ''

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -231,6 +231,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
         background: transparent;
         border: none;
         color: var(--paper-input-container-input-color, --primary-text-color);
+        -webkit-appearance: none;
 
         @apply(--paper-font-subhead);
         @apply(--paper-input-container-input);

--- a/paper-input.html
+++ b/paper-input.html
@@ -35,6 +35,14 @@ for `suffix`).
       <paper-icon-button suffix icon="clear"></paper-icon-button>
     </paper-input>
 
+A `paper-input` can use the native `type=search` features. However, since
+we can't control the native styling of the input, it's recommended to use
+a placeholder text, or `always-float-label`, as to not overlap the native search icon.
+
+    <paper-input label="search!" type="search"
+        placeholder="search for cats" autosave="test" results="5">
+    </paper-input>
+
 See `Polymer.PaperInputBehavior` for more API docs.
 
 ### Styling
@@ -106,7 +114,9 @@ style this element.
         size$="[[size]]"
         autocapitalize$="[[autocapitalize]]"
         autocorrect$="[[autocorrect]]"
-        on-change="_onChange">
+        on-change="_onChange"
+        autosave$="[[autosave]]",
+        results$="[[results]]">
 
       <content select="[suffix]"></content>
 


### PR DESCRIPTION
As usual, `<input type=...>` is a jar of spiders. In today's re-enactment, `type=search` has hilarious and inconsistent styles across browsers. This PR makes it sort of work with `paper-input` (and sorta fixes https://github.com/PolymerElements/paper-input/issues/178). The end result is:

Chrome:
<img width="326" alt="screen shot 2015-09-23 at 2 37 30 pm" src="https://cloud.githubusercontent.com/assets/1369170/10059716/803824b0-6201-11e5-9d33-606b42d9074c.png">

FF: (look how nice it is. sigh)
<img width="428" alt="screen shot 2015-09-23 at 2 38 16 pm" src="https://cloud.githubusercontent.com/assets/1369170/10059725/85c1c88c-6201-11e5-97cd-4d2083b30acb.png">

Safari:
<img width="444" alt="screen shot 2015-09-23 at 2 38 27 pm" src="https://cloud.githubusercontent.com/assets/1369170/10059730/8a55be12-6201-11e5-9570-4af391d80dcd.png">
Safari also successfully displays the spyglass, but I haven't managed to trick the other 2 to do that:
<img width="453" alt="screen shot 2015-09-23 at 2 49 33 pm" src="https://cloud.githubusercontent.com/assets/1369170/10059890/5f999ca6-6202-11e5-9834-b3be78d68437.png">

If you don't listen to the instructions and use a non-floated label, it looks amazing and there's nothing really that we can do about this (aside from putting in logic that forces you to auto-float the label if type="search". @cdata Should we do that? Sigh):
<img width="128" alt="screen shot 2015-09-23 at 2 23 21 pm" src="https://cloud.githubusercontent.com/assets/1369170/10059773/d113dd8e-6201-11e5-8696-afa65718f9f5.png">

I don't know what it looks on IE, but it's probably fine, right?

`<input>` or: why we can't have nice things. Tune in next week! :sob: