### PR TITLE
fix extra input-error spacing regression

### DIFF
--- a/paper-input-error.html
+++ b/paper-input-error.html
@@ -42,6 +42,7 @@ Custom property | Description | Default
 
         @apply(--paper-font-caption);
         @apply(--paper-input-error);
+        position: absolute;
       }
 
       :host([invalid]) {
@@ -50,7 +51,7 @@ Custom property | Description | Default
     </style>
 
     <content></content>
-
+    
   </template>
 </dom-module>
 


### PR DESCRIPTION
This was introduced because of https://github.com/PolymerElements/paper-input/pull/183
Turns out the point of the `float` was to pull the next input up and not add extra spacing. 

Proof that it looks nice now:
<img width="440" alt="screen shot 2015-09-29 at 2 19 06 pm" src="https://cloud.githubusercontent.com/assets/1369170/10178512/23a3b85a-66b5-11e5-88db-082d4444cc81.png">

Floats: :skull: 