### PR TITLE
less offsetParent recalc

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -532,9 +532,9 @@ This element is `display:block` by default, but you can set the `inline` attribu
           }
           // The label might have a horizontal offset if a prefix element exists
           // which needs to be undone when displayed as a floating label.
-          if (this.$.prefix && label && label.offsetParent &&
-              Polymer.dom(this.$.prefix).getDistributedNodes().length > 0) {
-           label.style.left = -label.offsetParent.offsetLeft + 'px';
+          if (Polymer.dom(this.$.prefix).getDistributedNodes().length > 0 &&
+              label && label.offsetParent) {
+            label.style.left = -label.offsetParent.offsetLeft + 'px';
           }
         } else {
           // When the label is not floating, it should overlap the input element.


### PR DESCRIPTION
This fixes the comment in https://github.com/PolymerElements/paper-input/issues/167#issuecomment-143912219

We don't really care about the `offsetParent` unless we have a prefix, so the `if` statement should bail out early if we don't.

I also think the `this.$.prefix` bit is always true because it just points to the `content` node, so I don't think it's needed.