### PR TITLE
Bind disabled attribute

### DIFF
--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -42,6 +42,7 @@ style this element.
       <iron-autogrow-textarea id="input" class="paper-input-input"
         bind-value="{{value}}"
         required$="[[required]]"
+        disabled$="[[disabled]]"
         maxlength$="[[maxlength]]"></iron-autogrow-textarea>
 
       <template is="dom-if" if="[[errorMessage]]">


### PR DESCRIPTION
Added an attribute to the iron-autogrow-textarea to pass the disabled state of paper-textarea.

Without this, the iron-autogrow-textarea is still focusable via javascript.


Note: needs [this pull request](https://github.com/PolymerElements/iron-autogrow-textarea/pull/44) to pass the attribute to the internal textarea