### PR TITLE
fix long labels on small screens

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -59,8 +59,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <div class="vertical-section">
       <paper-input label="label"></paper-input>
 
-      <paper-input label="search" type="search" placeholder="type='search' should use placeholders instead of labels" autosave="test" results="5"></paper-input>
-
       <paper-input label="password" type="password"></paper-input>
 
       <paper-input no-label-float label="label (no-label-float)"></paper-input>

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -186,6 +186,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
         font: inherit;
         color: var(--paper-input-container-color, --secondary-text-color);
 
+        @apply(--paper-font-common-nowrap);
         @apply(--paper-font-subhead);
         @apply(--paper-input-container-label);
       }
@@ -198,6 +199,10 @@ This element is `display:block` by default, but you can set the `inline` attribu
         transform-origin: left top;
         -webkit-transition: -webkit-transform 0.25s;
         transition: transform 0.25s;
+
+        /* Since we scale to 75/100 of the size, we actually have 100/75 of the
+        original space now available */
+        width: 133%;
 
         @apply(--paper-transition-easing);
       }


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-input/issues/192 with :sparkles: css magic :sparkles: 

Look at the nice truncated label:
<img width="209" alt="screen shot 2015-09-29 at 5 20 15 pm" src="https://cloud.githubusercontent.com/assets/1369170/10181567/9913e240-66ce-11e5-812a-e524f2d5acda.png">

And we get extra space when we float:
<img width="209" alt="screen shot 2015-09-29 at 5 50 19 pm" src="https://cloud.githubusercontent.com/assets/1369170/10181884/93fdeaae-66d2-11e5-8167-32ddccfd2d5a.png">

Unrelated: I've also deleted the `type=search` example from the demo, even though I just added it. It looks kind of weird, and we don't demo every other `type=`, so there's really no point (it does nothing special)

