### PR TITLE
Removed comma syntax error

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -117,7 +117,7 @@ style this element.
         autocapitalize$="[[autocapitalize]]"
         autocorrect$="[[autocorrect]]"
         on-change="_onChange"
-        autosave$="[[autosave]]",
+        autosave$="[[autosave]]"
         results$="[[results]]">
 
       <content select="[suffix]"></content>


### PR DESCRIPTION
A comma in the middle of attribute declarations for
`<input is="iron-input" ...>` was causing html-minifier to spin in an
endless loop.