### PR TITLE
Stop native validation kicking in when type is specified

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -344,7 +344,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         this.type = '';
 
-        console.debug('type set to null as native validation is on, add novalidate attribute to the containing form');
+        if (console && console.debug) {
+          console.debug('type set to null as native validation is on, add novalidate attribute to the containing form');
+        }
       }
     },
 

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -342,7 +342,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (form == null
             || !form.hasAttribute('novalidate')) {
 
-        this.type = null;
+        this.type = '';
 
         console.debug('type set to null as native validation is on, add novalidate attribute to the containing form');
       }

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -315,11 +315,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return this.$.input;
     },
 
-    attached: function() {
-      this._updateAriaLabelledBy();
+    /**
+     * Returns a reference to the input's form element (can be null).
+     */
+    getFormElement: function() {
+
+      if (this.form) return this.inputElement.form;
+      var parent = this;
+      while (parent = parent.parentElement) {
+        if (parent.tagName.toUpperCase() === 'FORM') return parent;
+      }
+
+      return null;
     },
 
-    _appendStringWithSpace: function(str, more) {
+    attached: function() {
+      this._updateAriaLabelledBy();
+      this._nullTypeWhenUsingNativeValidation();
+    },
+
+    _nullTypeWhenUsingNativeValidation: function () {
+      // find the associated form and check for novalidate attribute, 
+      // if not found nullify the input[type] to avoid native validation errors
+
+      var form = this.getFormElement();
+      if (form == null
+            || !form.hasAttribute('novalidate')) {
+
+        this.type = null;
+
+        console.debug('type set to null as native validation is on, add novalidate attribute to the containing form');
+      }
+    },
+
+    _appendStringWithSpace: function (str, more) {
       if (str) {
         str = str + ' ' + more;
       } else {

--- a/test/index.html
+++ b/test/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <!--
 Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
@@ -21,7 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'paper-textarea.html',
       'paper-input-container.html',
       'paper-input-error.html',
-      'paper-input-char-counter.html'
+      'paper-input-char-counter.html',
+      'paper-input-behavior-native-validation.html'
     ]);
   </script>
 </body>

--- a/test/paper-input-behavior-native-validation.html
+++ b/test/paper-input-behavior-native-validation.html
@@ -1,0 +1,106 @@
+﻿<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+  <title>paper-input-behavior native-validation tests</title>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+  <script src="../../iron-test-helpers/test-helpers.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
+
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../paper-input.html">
+
+</head>
+<body>
+
+  <test-fixture id="native-validation-no-form">
+    <template>
+      <paper-input type="tel"></paper-input>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="native-validation-with-form-novalidate-not-set">
+    <template>
+      <form>
+        <paper-input type="number"></paper-input>
+      </form>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="native-validation-with-form-novalidate-set">
+    <template>
+      <form novalidate>
+        <paper-input type="email"></paper-input>
+      </form>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    suite('native-validation', function () {
+
+      var getInputElement = function (element) {
+
+        element = element.tagName.toUpperCase() === 'PAPER-INPUT'
+          ? element
+          : Polymer.dom(element.root).querySelector('paper-input');
+
+        return element.inputElement;
+      }
+
+      test('when has no form, type set to null', function (done) {
+
+        var element = fixture('native-validation-no-form');
+        forceXIfStamp(element);
+        
+        var input = getInputElement(element);
+        assert.equal(input.getAttribute('type'), null);
+
+        done();
+      });
+
+      test('when has form, but novalidate is not found, type set to null', function (done) {
+
+        var element = fixture('native-validation-with-form-novalidate-not-set');
+        forceXIfStamp(element);
+
+        var input = getInputElement(element);
+        assert.equal(input.getAttribute('type'), null);
+
+        done();
+      });
+
+      test('when has form, novalidate is set, type set to "email"', function (done) {
+
+        var element = fixture('native-validation-with-form-novalidate-set');
+        forceXIfStamp(element);
+
+        var input = getInputElement(element);
+        assert.equal(input.getAttribute('type'), 'email');
+
+        done();
+      });
+
+    });
+  </script>
+
+</body>
+</html>

--- a/test/paper-input-behavior-native-validation.html
+++ b/test/paper-input-behavior-native-validation.html
@@ -55,7 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
 
-    suite('native-validation', function () {
+    suite('type and native validation', function () {
 
       var getInputElement = function (element) {
 
@@ -72,7 +72,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         forceXIfStamp(element);
         
         var input = getInputElement(element);
-        assert.equal(input.getAttribute('type'), null);
+        assert.equal(input.getAttribute('type'), '');
 
         done();
       });
@@ -83,7 +83,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         forceXIfStamp(element);
 
         var input = getInputElement(element);
-        assert.equal(input.getAttribute('type'), null);
+        assert.equal(input.getAttribute('type'), '');
 
         done();
       });


### PR DESCRIPTION
Check for a form associated input and the form[novalidate] attribute being set
if not found or the attribute not set then the input[type] is set to '' which stops native validation problems

a console message shows when this happens to give the developer a "heads up"
> type set to null as native validation is on, add novalidate attribute to the containing form

tests added

gold input will also have a change to set the input[type]="email", but I need to know the version of the dependency here before I do that one