### PR TITLE
update demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -45,8 +45,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     paper-icon-button {
       color: var(--paper-red-300);
       --paper-icon-button-ink-color: var(--paper-red-a100);
-      --iron-icon-width: 15px;
-      --iron-icon-height: 15px;
+      width: 23px; /* 15px + 2*4px for padding */
+      height: 23px;
       padding: 0px 4px;
     }
   </style>


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-input/issues/207: Since https://github.com/PolymerElements/paper-icon-button/pull/52 (that forced `paper-icon-button` to be content-sized) and https://github.com/PolymerElements/paper-icon-button/pull/41 (changed how to resize the icon) landed, this example was whack and needed to be updated.