### PR TITLE
add attributes for input type=file

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -293,6 +293,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         type: Number
       },
 
+      /**
+       * Bind this to the `<input is="iron-input">`'s `accept` property, , used with type=file.
+       */
+      accept: {
+        type: String
+      },
+
+      /**
+       * Bind this to the `<input is="iron-input">`'s `multiple` property, , used with type=file.
+       */
+      multiple: {
+        type: Boolean
+      },
+
       _ariaDescribedBy: {
         type: String,
         value: ''

--- a/paper-input.html
+++ b/paper-input.html
@@ -37,9 +37,10 @@ for `suffix`).
       <paper-icon-button suffix icon="clear"></paper-icon-button>
     </paper-input>
 
-A `paper-input` can use the native `type=search` features. However, since
-we can't control the native styling of the input, it's recommended to use
-a placeholder text, or `always-float-label`, as to not overlap the native search icon.
+A `paper-input` can use the native `type=search` or `type=file` features.
+However, since we can't control the native styling of the input, in these cases
+it's recommended to use a placeholder text, or `always-float-label`,
+as to not overlap the native UI (search icon, file button, etc.).
 
     <paper-input label="search!" type="search"
         placeholder="search for cats" autosave="test" results="5">
@@ -118,7 +119,9 @@ style this element.
         autocorrect$="[[autocorrect]]"
         on-change="_onChange"
         autosave$="[[autosave]]"
-        results$="[[results]]">
+        results$="[[results]]"
+        accept$="[[accept]]"
+        multiple$="[[multiple]]">
 
       <content select="[suffix]"></content>
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-input/issues/206

`<input>`: the gift that keeps on giving.
<img width="280" alt="screen shot 2015-10-20 at 4 09 58 pm" src="https://cloud.githubusercontent.com/assets/1369170/10623580/06aa5fb0-7745-11e5-888c-2ec9e81aff0a.png">
