### PR TITLE
input inherits the text-align from the container

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -237,6 +237,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
         border: none;
         color: var(--paper-input-container-input-color, --primary-text-color);
         -webkit-appearance: none;
+        text-align: inherit;
 
         @apply(--paper-font-subhead);
         @apply(--paper-input-container-input);
@@ -261,6 +262,10 @@ This element is `display:block` by default, but you can set the `inline` attribu
         resize: none;
       }
 
+      .add-on-content {
+        position: relative;
+      }
+      
       .add-on-content.is-invalid ::content * {
         color: var(--paper-input-container-invalid-color, --google-red-500);
       }

--- a/paper-input-error.html
+++ b/paper-input-error.html
@@ -43,6 +43,8 @@ Custom property | Description | Default
         @apply(--paper-font-caption);
         @apply(--paper-input-error);
         position: absolute;
+        left:0;
+        right:0;
       }
 
       :host([invalid]) {
@@ -51,7 +53,7 @@ Custom property | Description | Default
     </style>
 
     <content></content>
-    
+
   </template>
 </dom-module>
 


### PR DESCRIPTION
Fixes issue https://github.com/PolymerElements/paper-input/issues/106
Depends on https://github.com/PolymerElements/iron-autogrow-textarea/pull/51 when shadow dom is used.
Allows alignment of <code>paper-input, paper-textarea, paper-input-container</code> to be applied to the children (aka children will inherit the text-align from the container)
With this PR, users will be able to apply styles like:
```css
paper-textarea,
paper-input,
paper-input-container {
  text-align: center;
}
```

- takes care of placement of the label, input
<img width="1080" alt="screen shot 2015-10-26 at 10 54 24 am" src="https://cloud.githubusercontent.com/assets/6173664/10737536/0078b62a-7bd0-11e5-9be0-a1ffa4d36b3b.png">
- takes care of add-on-content
<img width="543" alt="screen shot 2015-10-26 at 6 39 06 pm" src="https://cloud.githubusercontent.com/assets/6173664/10747313/e5dd1cf2-7c10-11e5-9a44-96482217be89.png">

Known issue: alignment of the label when paper-input has prefix/suffix content (to be tackled in a separate PR)
<img width="303" alt="screen shot 2015-10-26 at 12 34 58 pm" src="https://cloud.githubusercontent.com/assets/6173664/10740190/1c151488-7bde-11e5-96d7-acc626a25814.png">