### PR TITLE
Allow reusing the paper-input template

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -333,6 +333,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._updateAriaLabelledBy();
     },
 
+    ready: function() {
+      // If there's an initial input, validate it.
+      if (this.value)
+        this._handleAutoValidate();
+    },
+
     _appendStringWithSpace: function(str, more) {
       if (str) {
         str = str + ' ' + more;

--- a/paper-input.html
+++ b/paper-input.html
@@ -59,7 +59,7 @@ style this element.
 @demo demo/index.html
 -->
 
-<dom-module id="paper-input">
+<dom-module id="paper-input-template">
   <template>
 
     <style>
@@ -144,8 +144,12 @@ style this element.
 
     behaviors: [
       Polymer.IronFormElementBehavior,
-      Polymer.PaperInputBehavior,
-      Polymer.IronControlState
-    ]
+      Polymer.PaperInputBehavior
+    ],
+
+    // Manually import the template, so that other elements can re-use it.
+    beforeRegister: function() {
+      this._template = Polymer.DomModule.import('paper-input-template', 'template');
+    }
   });
 </script>


### PR DESCRIPTION
Moves the paper-input `<template>` to a named `dom-module`, so that `gold-*` elements can reuse it and stop copy pasting all of it.

Minor fixes:
- `PaperInputBehavior` already includes `IronControlState`, so don't include it twice
- should auto-validate on `ready()`. The `paper-input-container` already does this, but if the template
is cloned and we chose to manually do the auto-validation (i.e.