### PR TITLE
fix prefix-related CSS

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -276,7 +276,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
 
     <div class$="[[_computeInputContentClass(noLabelFloat,alwaysFloatLabel,focused,invalid,_inputHasContent)]]">
       <content select="[prefix]" id="prefix"></content>
-      <div class="label-and-input-container">
+
+      <div class="label-and-input-container" id="labelAndInputContainer">
         <content select=":not([add-on]):not([prefix]):not([suffix])"></content>
       </div>
       <content select="[suffix]"></content>
@@ -439,6 +440,21 @@ This element is `display:block` by default, but you can set the `inline` attribu
       } else {
         this._handleValue(this._inputElement);
       }
+
+      this._numberOfPrefixNodes = 0;
+      this._prefixObserver = Polymer.dom(this.$.prefix).observeNodes(
+          function(mutations) {
+            // Keep track whether there's at least one prefix node, since it
+            // affects laying out the floating label.
+            this._numberOfPrefixNodes += mutations.addedNodes.length -
+                mutations.removedNodes.length;
+          }.bind(this));
+    },
+
+    detached: function() {
+      if (this._prefixObserver) {
+        Polymer.dom(this.$.prefix).unobserveNodes(this._prefixObserver);
+      }
     },
 
     _onAddonAttached: function(event) {
@@ -535,16 +551,15 @@ This element is `display:block` by default, but you can set the `inline` attribu
           } else if (focused) {
             cls += " label-is-highlighted";
           }
-          // The label might have a horizontal offset if a prefix element exists
+          // If a prefix element exists, the label has a horizontal offset
           // which needs to be undone when displayed as a floating label.
-          if (Polymer.dom(this.$.prefix).getDistributedNodes().length > 0 &&
-              label && label.offsetParent) {
-            label.style.left = -label.offsetParent.offsetLeft + 'px';
+          if (this._numberOfPrefixNodes > 0) {
+            this.$.labelAndInputContainer.style.position = 'static';
           }
         } else {
           // When the label is not floating, it should overlap the input element.
           if (label) {
-            label.style.left = 0;
+            this.$.labelAndInputContainer.style.position = 'relative';
           }
         }
       } else {


### PR DESCRIPTION
Ohhhhh boy. This PR. So many things:
- Fixes whatever is left of https://github.com/PolymerElements/paper-input/issues/167, because we :bomb: `offsetParent`
- We no longer do a really gross offset calculation if there's a prefix AND it still looks good because future monica knows more CSS than past monica:
<img width="231" alt="screen shot 2015-10-26 at 6 28 40 pm" src="https://cloud.githubusercontent.com/assets/1369170/10747393/d6e96d8a-7c11-11e5-89bc-e0ac3b105766.png">

- Fixes https://github.com/PolymerElements/paper-input/issues/149 because we now know when the prefix has been added and removed! :two_hearts: 