### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/paper-input-char-counter.html
+++ b/paper-input-char-counter.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../paper-styles/typography.html">
 <link rel="import" href="paper-input-addon-behavior.html">
 
 <!--

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -9,7 +9,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../paper-styles/color.html">
+<link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 
 <!--
 `<paper-input-container>` is a container for a `<label>`, an `<input is="iron-input">` or
@@ -120,6 +123,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
 
       .focused-line {
         height: 2px;
+        @apply(--layout-fit);
 
         -webkit-transform-origin: center center;
         transform-origin: center center;
@@ -153,6 +157,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
 
       .unfocused-line {
         height: 1px;
+        @apply(--layout-fit);
         background: var(--paper-input-container-color, --secondary-text-color);
 
         @apply(--paper-input-container-underline);
@@ -300,8 +305,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
     </div>
 
     <div class$="[[_computeUnderlineClass(focused,invalid)]]">
-      <div class="unfocused-line fit"></div>
-      <div class="focused-line fit"></div>
+      <div class="unfocused-line"></div>
+      <div class="focused-line"></div>
     </div>
 
     <div class$="[[_computeAddOnContentClass(focused,invalid)]]">

--- a/paper-input-error.html
+++ b/paper-input-error.html
@@ -9,7 +9,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../paper-styles/color.html">
+<link rel="import" href="../paper-styles/typography.html">
 <link rel="import" href="paper-input-addon-behavior.html">
 
 <!--


### PR DESCRIPTION
Removes any use of the `/deep/` flex classes. One step closer away from dragons 🐉🎉 

Before:
<img width="825" alt="screen shot 2015-11-12 at 3 31 37 pm" src="https://cloud.githubusercontent.com/assets/1369170/11134630/24c1e3ea-8953-11e5-99e4-bbf80749d4eb.png">

After:
<img width="463" alt="screen shot 2015-11-12 at 3 33 02 pm" src="https://cloud.githubusercontent.com/assets/1369170/11134632/268a88e4-8953-11e5-983d-955a9285401f.png">

And hopefully nothing else :(

(I would release this as a minor version bump, P.S)