### PR TITLE
add the reflectToAttribute to invalid property

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -361,6 +361,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       invalid: {
         observer: '_invalidChanged',
         type: Boolean,
+        reflectToAttribute: true,
         value: false
       },
 

--- a/paper-input-error.html
+++ b/paper-input-error.html
@@ -48,7 +48,7 @@ Custom property | Description | Default
         right:0;
       }
 
-      :host([invalid]) {
+      :host-context([invalid]) {
         visibility: visible;
       };
     </style>
@@ -65,20 +65,5 @@ Custom property | Description | Default
     behaviors: [
       Polymer.PaperInputAddonBehavior
     ],
-
-    properties: {
-      /**
-       * True if the error is showing.
-       */
-      invalid: {
-        readOnly: true,
-        reflectToAttribute: true,
-        type: Boolean
-      }
-    },
-
-    update: function(state) {
-      this._setInvalid(state.invalid);
-    }
   });
 </script>

--- a/test/paper-input-error.html
+++ b/test/paper-input-error.html
@@ -54,6 +54,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var error = Polymer.dom(container).querySelector('#e');
         assert.equal(getComputedStyle(error).visibility, 'hidden', 'error is visibility:hidden');
         input.bindValue = 'foobar';
+        assert(container.invalid, 'invalid should be set to true');
+        assert(container.hasAttribute('invalid'), 'invalid attribute should be set');
         assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
       });
 


### PR DESCRIPTION
Hi,
while developing a custom element based on `<paper-input-container>`, I needed an add-on that required to know the invalid state of the component. I therefore, decided to use:
```css
      :host-context([invalid]) {
        visibility: hidden;
      };
```
It does not work however, because `invalid` is not reflected to attributes.
Looking at `<paper-input-error>`, I discovered that an invalid property is duplicated and itself reflected to attributes.
This PR simplifies and reduces the code accordingly.
I also updated the relevant test.