### PR TITLE
center the input-related-elements vertically

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -179,7 +179,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-content {
         position: relative;
         @apply(--layout-horizontal);
-        @apply(--layout-end);
+        @apply(--layout-center);
       }
 
       .input-content ::content label,


### PR DESCRIPTION
This way the prefixes, sufixes and the label will be aligned vertically (vs. aligned at the bottom, which makes them look sad)

/cc @ebidel 