### PR TITLE
added paper-input-addon-behavior to main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
     "paper-input-behavior.html",
     "paper-input-container.html",
     "paper-input-error.html",
+    "paper-input-addon-behavior.html",
     "paper-input-char-counter.html"
   ],
   "private": true,


### PR DESCRIPTION
Fixes #281 

The component `paper-input-addon-behavior.html` was added to main since `paper-input-error` requires it.