### PR TITLE
bind title attribute

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -100,6 +100,7 @@ style this element.
         aria-labelledby$="[[_ariaLabelledBy]]"
         aria-describedby$="[[_ariaDescribedBy]]"
         disabled$="[[disabled]]"
+        title$="[[title]]"
         bind-value="{{value}}"
         invalid="{{invalid}}"
         prevent-invalid-input="[[preventInvalidInput]]"


### PR DESCRIPTION
This PR attempts binds the title attribute that a paper-input is invoked with to the title attribute of the native input element in its template. This is useful because when you provide a pattern attribute that is not matched by the user's input, the browser will show your title to the user to help them figure out how to correct their input.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

> Use the title attribute to describe the pattern to help the user.

See also "Title Attribute" section of http://www.html5rocks.com/en/tutorials/forms/constraintvalidation/