### PR TITLE
paper-input temporarily creates a horizontal scrollbar after typing first letter #277

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -71,6 +71,7 @@ style this element.
     <style>
       :host {
         display: block;
+        overflow: hidden;
       }
 
       input::-webkit-input-placeholder {

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -37,6 +37,7 @@ style this element.
     <style>
       :host {
         display: block;
+        overflow: hidden;
       }
     </style>
 


### PR DESCRIPTION
I added "overflow: hidden" to paper-input and paper-textarea to prevent the scrollbar.
This is a variant of robrez's fix in #277.
Not sure of the larger implications of this change.