### PR TITLE
bind oninvalid

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -224,6 +224,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
+       * Bind this to the `<input is="iron-input">`'s `oninvalid` property.
+       */
+      oninvalid: {
+        type: String
+      },
+
+      /**
        * Limits the numeric or date-time increments.
        * Bind this to the `<input is="iron-input">`'s `step` property.
        */

--- a/paper-input.html
+++ b/paper-input.html
@@ -100,6 +100,7 @@ style this element.
         aria-labelledby$="[[_ariaLabelledBy]]"
         aria-describedby$="[[_ariaDescribedBy]]"
         disabled$="[[disabled]]"
+        title$="[[title]]"
         bind-value="{{value}}"
         invalid="{{invalid}}"
         prevent-invalid-input="[[preventInvalidInput]]"

--- a/paper-input.html
+++ b/paper-input.html
@@ -103,6 +103,7 @@ style this element.
         title$="[[title]]"
         bind-value="{{value}}"
         invalid="{{invalid}}"
+        oninvalid$="[[oninvalid]]"
         prevent-invalid-input="[[preventInvalidInput]]"
         allowed-pattern="[[allowedPattern]]"
         validator="[[validator]]"


### PR DESCRIPTION
This enables binding to a paper-input's contained native input's `oninvalid` attribute, which allows setting completely custom error messages with something like `<paper-input ... oninvalid="setCustomValidity('Custom Message')")>`:

![screen shot 2016-01-02 at 11 13 40](https://cloud.githubusercontent.com/assets/64992/12075083/183afa6e-b142-11e5-844e-e245c3d58176.png)
