### PR TITLE
Satisfying polylint

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -316,8 +316,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _ariaLabelledBy: {
         type: String,
         value: ''
-      }
+      },
 
+      /**
+       * Bind this to the `<input is="iron-input">`'s` `tabindex` property.
+       */
+      tabindex: {
+        type: Number
+      }
     },
 
     listeners: {


### PR DESCRIPTION
Polylint is giving the following output:

```
$ polylint --input demo/index.html 
paper-input.html:99:7
    Property 'tabindex' bound to attribute 'tabindex$' not found in 'properties' for element 'paper-input'
```

After adding the `tabindex` property to the `paper-input-behavior` the error is gone. If you want the `tabindex` to be before the private `_ariaDescribedBy` and `_ariaLabelledBy` property I can update my PR.

