### PR TITLE
paper-input temporarily creates a horizontal scrollbar after typing first letter #277 #294

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -189,6 +189,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
         top: 0;
         right: 0;
         left: 0;
+        width: 100%;
         font: inherit;
         color: var(--paper-input-container-color, --secondary-text-color);
 
@@ -201,8 +202,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-content.label-is-floating ::content .paper-input-label {
         -webkit-transform: translateY(-75%) scale(0.75);
         transform: translateY(-75%) scale(0.75);
-        -webkit-transition: -webkit-transform 0.25s;
-        transition: transform 0.25s;
+        -webkit-transition: -webkit-transform 0.25s, width 0.25s;
+        transition: transform 0.25s, width 0.25s;
         -webkit-transform-origin: left top;
         transform-origin: left top;
 

--- a/paper-input.html
+++ b/paper-input.html
@@ -71,7 +71,6 @@ style this element.
     <style>
       :host {
         display: block;
-        overflow: hidden;
       }
 
       input::-webkit-input-placeholder {

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -37,7 +37,6 @@ style this element.
     <style>
       :host {
         display: block;
-        overflow: hidden;
       }
     </style>
 


### PR DESCRIPTION
fixing temporary scrollbar again
Removing the overflow hidden that killed the error labels.
Changing width to animate with scaling so the strange width:133% + scale(0.75) stuff will be applied at the same rate. Had to apply an initial width to get this to work.
I tested on windows in chrome, IE and Edge.
Didn't notice any issues.