### PR TITLE
Autofloat label for special types

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -394,8 +394,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return this.inputElement;
     },
 
+    registered: function() {
+      // These types have some default placeholder text; overlapping
+      // the label on top of it looks terrible. Auto-float the label in this case.
+      this._typesThatHaveText = ["date", "datetime", "datetime-local", "month",
+          "time", "week", "file"];
+    },
+
     attached: function() {
       this._updateAriaLabelledBy();
+
+      if (this.inputElement &&
+          this._typesThatHaveText.indexOf(this.inputElement.type) !== -1) {
+        this.alwaysFloatLabel = true;
+      }
     },
 
     _appendStringWithSpace: function(str, more) {

--- a/paper-input.html
+++ b/paper-input.html
@@ -39,9 +39,10 @@ for `suffix`).
     </paper-input>
 
 A `paper-input` can use the native `type=search` or `type=file` features.
-However, since we can't control the native styling of the input, in these cases
-it's recommended to use a placeholder text, or `always-float-label`,
-as to not overlap the native UI (search icon, file button, etc.).
+However, since we can't control the native styling of the input (search icon,
+file button, date placeholder, etc.), in these cases the label will be
+automatically floated. The `placeholder` attribute can still be used for
+additional informational text.
 
     <paper-input label="search!" type="search"
         placeholder="search for cats" autosave="test" results="5">

--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -70,7 +70,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-
   <test-fixture id="required-char-counter">
     <template>
       <paper-input auto-validate char-counter required error-message="error"></paper-input>
@@ -92,6 +91,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="placeholder">
     <template>
       <paper-input label="foo" placeholder="bar"></paper-input>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="date">
+    <template>
+      <paper-input label="foo" type="date"></paper-input>
     </template>
   </test-fixture>
 
@@ -119,6 +124,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(input.noLabelFloat, false);
         var floatingLabel = Polymer.dom(Polymer.dom(input.root).querySelector('paper-input-container').root).querySelector('.label-is-floating');
         assert.ok(floatingLabel);
+      });
+
+      test('special types autofloat the label', function() {
+        var input = fixture('date');
+        // Browsers that don't support special <input> types like `date` fallback
+        // to `text`, so make sure to only test if type is still preserved after
+        // the element is attached.
+        if (input.inputElement.type === "date") {
+          assert.equal(input.alwaysFloatLabel, true);
+          var floatingLabel = Polymer.dom(Polymer.dom(input.root).querySelector('paper-input-container').root).querySelector('.label-is-floating');
+          assert.ok(floatingLabel);
+        }
       });
 
       test('always-float-label attribute works without placeholder', function() {


### PR DESCRIPTION
Fixes #291 .
Despite saying in the docs you shouldn't do this, it's a bit surprising when the label overlaps some native input's default placeholder (things like `type="date"` always have a placeholder). So I'm admitting defeat and fixing this, and auto-floating the label in that case.