### PR TITLE
prevent _inputElementValue returning undefined

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -449,7 +449,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
     },
 
     get _inputElementValue() {
-      return this._inputElement[this._propertyForValue] || this._inputElement.value;
+      return this._inputElement[this._propertyForValue] || this._inputElement.value || '';
     },
 
     ready: function() {


### PR DESCRIPTION
For paper-textarea ```paper-input-container._inputElementValue()``` getter can return ```undefined```. This makes paper-textareas (without a value attribute or a value binding to an undefined property) to be auto-validated on attach, because  ```paper-input-container``` [compares against an empty string](https://github.com/PolymerElements/paper-input/blob/master/paper-input-container.html#L470).


Consider the different behavior:
```
<paper-input required auto-validate error-message="needs some text!"></paper-input>
<paper-textarea required auto-validate error-message="needs some text!"></paper-textarea>
```
jsbin: http://jsbin.com/jusutamihe/edit?html,output

I fixed it by falling back to an empty string. Howerver, I think that ```iron-autogrow-textarea``` causes the issue, because it can have undefined values. For layer-compatibilty to iron, my fix increases robustness.
