### PR TITLE
Apply the transition effect for floating labels moving back to their …

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -196,6 +196,10 @@ This element is `display:block` by default, but you can set the `inline` attribu
         width: 100%;
         font: inherit;
         color: var(--paper-input-container-color, --secondary-text-color);
+        -webkit-transition: -webkit-transform 0.25s, width 0.25s;
+        transition: transform 0.25s, width 0.25s;
+        -webkit-transform-origin: left top;
+        transform-origin: left top;
 
         @apply(--paper-font-common-nowrap);
         @apply(--paper-font-subhead);
@@ -206,10 +210,6 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-content.label-is-floating ::content .paper-input-label {
         -webkit-transform: translateY(-75%) scale(0.75);
         transform: translateY(-75%) scale(0.75);
-        -webkit-transition: -webkit-transform 0.25s, width 0.25s;
-        transition: transform 0.25s, width 0.25s;
-        -webkit-transform-origin: left top;
-        transform-origin: left top;
 
         /* Since we scale to 75/100 of the size, we actually have 100/75 of the
         original space now available */

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -204,6 +204,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
         @apply(--paper-font-common-nowrap);
         @apply(--paper-font-subhead);
         @apply(--paper-input-container-label);
+        @apply(--paper-transition-easing);
       }
 
       .input-content.label-is-floating ::content label,
@@ -215,7 +216,6 @@ This element is `display:block` by default, but you can set the `inline` attribu
         original space now available */
         width: 133%;
 
-        @apply(--paper-transition-easing);
         @apply(--paper-input-container-label-floating);
       }
 


### PR DESCRIPTION
…non-floated state.

paper-input-containers with floating labels (that don't have always-float-label set) move their label into the top right corner and shrink it down when text is entered into the input.
There's a short transition that animates this transition.

However, when deleting the text so that the input ends up empty, the label snaps back to its initial position in the input immediately, with no transition applied. This happens because the transition is only defined in CSS for when the input-content has the class **label-is-floating**.

This pull request applies the transition for the label in both states, floating and not floating, so that when it goes from its floating state back to its initial non-floating state, it will still be animated.