### PR TITLE
add IronFormElementBehavior to paper-textarea

### DIFF
--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-autogrow-textarea/iron-autogrow-textarea.html">
+<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 <link rel="import" href="paper-input-behavior.html">
 <link rel="import" href="paper-input-char-counter.html">
 <link rel="import" href="paper-input-container.html">
@@ -77,7 +78,8 @@ style this element.
     is: 'paper-textarea',
 
     behaviors: [
-      Polymer.PaperInputBehavior
+      Polymer.PaperInputBehavior,
+      Polymer.IronFormElementBehavior
     ],
 
     properties: {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-autogrow-textarea/issues/33

This is part of a 3-headed hydra of PRs that is trying to fix the following problem: `iron-form` was bad at de-duping nested elements with the same `name`, and would double submit them. The problem was that if you bind the `name` attribute all the way down, and these children you're binding it to are either native elements (so the form automatically cares about them) or custom elements with the `IronFormElementBehavior`, you would submit the same value twice.

This PR adds the correct `IronFormElementBehavior` to the element, since it's an element that wants to work in a form, and that's what the behavior does.

Landing this without the other 3 means that a `paper-textarea` will be submitted twice.

Related PRs:
- https://github.com/PolymerElements/iron-autogrow-textarea/pull/74
- https://github.com/PolymerElements/iron-form/pull/110