### PR TITLE
<paper-textarea> placeholder color styles correctly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.2.0",
-    "iron-autogrow-textarea": "PolymerElements/iron-autogrow-textarea#^1.0.0",
+    "iron-autogrow-textarea": "PolymerElements/iron-autogrow-textarea#^1.0.11",
     "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
     "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
     "iron-input": "PolymerElements/iron-input#^1.0.0",

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -39,6 +39,12 @@ style this element.
       :host {
         display: block;
       }
+
+      iron-autogrow-textarea {
+        --iron-autogrow-textarea-placeholder: {
+          color: var(--paper-input-container-color, --secondary-text-color);
+        };
+      }
     </style>
 
     <paper-input-container no-label-float$="[[noLabelFloat]]" always-float-label="[[_computeAlwaysFloatLabel(alwaysFloatLabel,placeholder)]]" auto-validate$="[[autoValidate]]" disabled$="[[disabled]]" invalid="[[invalid]]">


### PR DESCRIPTION
Adds in styling for `<paper-textarea>`'s placeholder to match `<paper-input>`. You can see the color difference on the current release with the following snippet:

```html
<paper-input label="Label" placeholder="I'm Right!"></paper-input>
<paper-textarea label="Label" placeholder="I'm sad :("><paper-textarea>
```

It's even more obvious if you set either a `--paper-input-container-color` or `--secondary-text-color`.