### PR TITLE
Fix closure compiler error (using Chromium settings).

### DIFF
--- a/paper-input-addon-behavior.html
+++ b/paper-input-addon-behavior.html
@@ -31,10 +31,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * The function called by `<paper-input-container>` when the input value or validity changes.
      * @param {{
-     *   inputElement: (Node|undefined),
+     *   inputElement: (Element|undefined),
      *   value: (string|undefined),
-     *   invalid: (boolean|undefined)
-     * }} state All properties are optional -
+     *   invalid: boolean
+     * }} state -
      *     inputElement: The input element.
      *     value: The input value.
      *     invalid: True if the input value is invalid.

--- a/paper-input-char-counter.html
+++ b/paper-input-char-counter.html
@@ -65,6 +65,17 @@ Custom property | Description | Default
       }
     },
 
+    /**
+     * This overrides the update function in PaperInputAddonBehavior.
+     * @param {{
+     *   inputElement: (Element|undefined),
+     *   value: (string|undefined),
+     *   invalid: boolean
+     * }} state -
+     *     inputElement: The input element.
+     *     value: The input value.
+     *     invalid: True if the input value is invalid.
+     */
     update: function(state) {
       if (!state.inputElement) {
         return;
@@ -72,7 +83,7 @@ Custom property | Description | Default
 
       state.value = state.value || '';
 
-      var counter = state.value.length;
+      var counter = state.value.length.toString();
 
       if (state.inputElement.hasAttribute('maxlength')) {
         counter += '/' + state.inputElement.getAttribute('maxlength');

--- a/paper-input-error.html
+++ b/paper-input-error.html
@@ -76,6 +76,17 @@ Custom property | Description | Default
       }
     },
 
+    /**
+     * This overrides the update function in PaperInputAddonBehavior.
+     * @param {{
+     *   inputElement: (Element|undefined),
+     *   value: (string|undefined),
+     *   invalid: boolean
+     * }} state -
+     *     inputElement: The input element.
+     *     value: The input value.
+     *     invalid: True if the input value is invalid.
+     */
     update: function(state) {
       this._setInvalid(state.invalid);
     }


### PR DESCRIPTION
Hello,

This fixes a closure compiler issue when we compile this with the Chromium settings.

Note, that this header is duplicated text from PaperInputAddonBehavior. I tried using @override, but that did not work. I'm open to suggestions if there's a better way to do this.

If accepted, can we also roll the version so Chromium can pull the new version of paper-input? Thanks.

Tommy