### PR TITLE
aria-hide the label since it's not needed

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -310,7 +310,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
     </style>
 
     <template is="dom-if" if="[[!noLabelFloat]]">
-      <div class="floated-label-placeholder">&nbsp;</div>
+      <div class="floated-label-placeholder" aria-hidden="true">&nbsp;</div>
     </template>
 
     <div class$="[[_computeInputContentClass(noLabelFloat,alwaysFloatLabel,focused,invalid,_inputHasContent)]]">

--- a/paper-input.html
+++ b/paper-input.html
@@ -95,7 +95,7 @@ style this element.
 
       <content select="[prefix]"></content>
 
-      <label hidden$="[[!label]]">[[label]]</label>
+      <label hidden$="[[!label]]" aria-hidden="true">[[label]]</label>
 
       <input is="iron-input" id="input"
         aria-labelledby$="[[_ariaLabelledBy]]"

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -43,7 +43,7 @@ style this element.
 
     <paper-input-container no-label-float$="[[noLabelFloat]]" always-float-label="[[_computeAlwaysFloatLabel(alwaysFloatLabel,placeholder)]]" auto-validate$="[[autoValidate]]" disabled$="[[disabled]]" invalid="[[invalid]]">
 
-      <label hidden$="[[!label]]">[[label]]</label>
+      <label hidden$="[[!label]]" aria-hidden="true">[[label]]</label>
 
       <iron-autogrow-textarea id="input" class="paper-input-input"
         bind-value="{{value}}"


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-input/issues/231

The label can be `aria-hidden` since it's already being read out as part of the `input`'s `aria-labelledby`.

Don't merge yet: currently blocked on https://bugs.chromium.org/p/chromium/issues/detail?id=595494
