### PR TITLE
fixed browser back/forward input field value

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -103,6 +103,7 @@ style this element.
         disabled$="[[disabled]]"
         title$="[[title]]"
         bind-value="{{value}}"
+        value$="[[value]]"
         invalid="{{invalid}}"
         prevent-invalid-input="[[preventInvalidInput]]"
         allowed-pattern="[[allowedPattern]]"


### PR DESCRIPTION
when user moved back/forward value in the field is not saved, although standard browser behaviour is to save state/value of input fields 
fixed for Safari/Firefox (Chrome didn't have this issue)