### PR TITLE
Revert "fixed browser back/forward input field value"

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -103,7 +103,6 @@ style this element.
         disabled$="[[disabled]]"
         title$="[[title]]"
         bind-value="{{value}}"
-        value$="[[value]]"
         invalid="{{invalid}}"
         prevent-invalid-input="[[preventInvalidInput]]"
         allowed-pattern="[[allowedPattern]]"


### PR DESCRIPTION
Reverts PolymerElements/paper-input#368, since it causes https://github.com/PolymerElements/paper-input/issues/377.

