### PR TITLE
Clear the focused attribute on blur from shift-tab. Fixes #386

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -446,13 +446,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Forward focus to inputElement. Overriden from IronControlState.
      */
     _focusBlurHandler: function(event) {
-      if (this._shiftTabPressed)
-        return;
-
       Polymer.IronControlState._focusBlurHandler.call(this, event);
 
       // Forward the focus to the nested input.
-      if (this.focused)
+      if (this.focused && !this._shiftTabPressed)
         this._focusableElement.focus();
     },
 

--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -251,6 +251,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         MockInteractions.blur(input.inputElement);
         assert(!input.focused, 'input is blurred');
       });
+
+      test('focusing then bluring with shift-tab removes the focused attribute correctly', function() {
+        MockInteractions.focus(input);
+        assert(input.focused, 'input is focused');
+
+        // Fake a shift-tab induced blur by forcing the flag.
+        input._shiftTabPressed = true;
+        MockInteractions.blur(input.inputElement);
+        assert(!input.focused, 'input is blurred');
+      });
     });
 
     suite('focused styling (integration test)', function() {


### PR DESCRIPTION
This PR fixes clearing of the `focused` attribute when the blur occurs as a result of `shift-tab` key combination. Basically this was fixed by always calling the `_focusBlurHandler` of `IronControlState` even when the `_shiftTabPressed` flag is set.