### PR TITLE
Fixes #394

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -272,6 +272,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
         color: var(--paper-input-container-input-color, --primary-text-color);
         -webkit-appearance: none;
         text-align: inherit;
+        vertical-align:bottom;
 
         @apply(--paper-font-subhead);
         @apply(--paper-input-container-input);

--- a/test/paper-textarea.html
+++ b/test/paper-textarea.html
@@ -125,6 +125,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var inputContent = Polymer.dom(container.root).querySelector('.input-content');
         assert.isTrue(inputContent.classList.contains('label-is-floating'), 'label is floating');
       });
+
+      test('no extra space between input and underline', function() {
+        var input = fixture('label');
+        var container = Polymer.dom(input.root).querySelector('paper-input-container');
+        var inputContent = Polymer.dom(container.root).querySelector('.input-content');
+        var ironTextarea = Polymer.dom(input.root).querySelector('iron-autogrow-textarea');
+        assert.equal(inputContent.clientHeight,ironTextarea.clientHeight, 'container and textarea are same height');
+      });
+
     });
 
     suite('focus/blur events', function() {


### PR DESCRIPTION
Adds vertical-align:bottom to input. Only an issue when doctype is declared. Fixes #394 