### PR TITLE
Fixing #408: A11y: Upon showing an error using error-message attribute no verbalisation is given.

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -139,7 +139,7 @@ style this element.
       <content select="[suffix]"></content>
 
       <template is="dom-if" if="[[errorMessage]]">
-        <paper-input-error>[[errorMessage]]</paper-input-error>
+        <paper-input-error aria-live="assertive">[[errorMessage]]</paper-input-error>
       </template>
 
       <template is="dom-if" if="[[charCounter]]">


### PR DESCRIPTION
Fixing #408
Adding aria-live="assertive" to the error message in paper-input.