### PR TITLE
Remove default outline

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -73,6 +73,10 @@ style this element.
       :host {
         display: block;
       }
+      
+      :host([focused]) {
+        outline: none;
+      }
 
       :host([hidden]) {
         display: none !important;


### PR DESCRIPTION
In the chrome html.css an outline is added on focused. The paper-input already has a way of focusing (the blue underbar) that doesn't involve the outline box. The outline box is redundant and distracting.

Fixes #415