### PR TITLE
no pointer events for label

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -73,7 +73,7 @@ style this element.
       :host {
         display: block;
       }
-      
+
       :host([focused]) {
         outline: none;
       }
@@ -96,6 +96,10 @@ style this element.
 
       input:-ms-input-placeholder {
         color: var(--paper-input-container-color, --secondary-text-color);
+      }
+
+      label {
+        pointer-events: none;
       }
     </style>
 

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -43,6 +43,10 @@ style this element.
       :host([hidden]) {
         display: none !important;
       }
+
+      label {
+        pointer-events: none;
+      }
     </style>
 
     <paper-input-container no-label-float$="[[noLabelFloat]]" always-float-label="[[_computeAlwaysFloatLabel(alwaysFloatLabel,placeholder)]]" auto-validate$="[[autoValidate]]" disabled$="[[disabled]]" invalid="[[invalid]]">

--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -161,6 +161,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isTrue(inputContent.classList.contains('label-is-floating'), 'label is floating');
       });
 
+      test('label does not receive pointer events', function() {
+        var input = fixture('always-float-label');
+        var label = Polymer.dom(input.root).querySelector('label');
+        assert.equal(getComputedStyle(label).pointerEvents, 'none');
+      });
+
       test('error message is displayed', function() {
         var input = fixture('error');
         forceXIfStamp(input);

--- a/test/paper-textarea.html
+++ b/test/paper-textarea.html
@@ -125,6 +125,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var inputContent = Polymer.dom(container.root).querySelector('.input-content');
         assert.isTrue(inputContent.classList.contains('label-is-floating'), 'label is floating');
       });
+
+      test('label does not receive pointer events', function() {
+        var input = fixture('always-float-label');
+        var label = Polymer.dom(input.root).querySelector('label');
+        assert.equal(getComputedStyle(label).pointerEvents, 'none');
+      });
     });
 
     suite('focus/blur events', function() {


### PR DESCRIPTION
Fixes #418 by disabling pointer events for `label` in `paper-input` and `paper-textarea`.
This is not done in `paper-input-container` as it might remotely be a breaking change for whoever is counting on pointer events on the label. Moreover, users of `paper-input-container` can already disable pointer events by using the mixin `--paper-input-container-label`