### PR TITLE
Add missing binding for invalid property to paper-textarea.

### DIFF
--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -55,6 +55,7 @@ style this element.
 
       <iron-autogrow-textarea id="input" class="paper-input-input"
         bind-value="{{value}}"
+        invalid="{{invalid}}"
         disabled$="[[disabled]]"
         autocomplete$="[[autocomplete]]"
         autofocus$="[[autofocus]]"


### PR DESCRIPTION
This prevents the invalid property from getting out of sync when it it for example set from an outside component.