### PR TITLE
Added mixins to style with different invalid colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,13 +176,16 @@ The following custom properties and mixins are available for styling:
 | `--paper-input-container-disabled` | Mixin applied to the container when it's disabled | `{}` |
 | `--paper-input-container-label` | Mixin applied to the label | `{}` |
 | `--paper-input-container-label-focus` | Mixin applied to the label when the input is focused | `{}` |
+| `--paper-input-container-label-invalid` | Mixin applied to the label when the input is invalid | `{}` |
 | `--paper-input-container-label-floating` | Mixin applied to the label when floating | `{}` |
 | `--paper-input-container-input` | Mixin applied to the input | `{}` |
 | `--paper-input-container-underline` | Mixin applied to the underline | `{}` |
 | `--paper-input-container-underline-focus` | Mixin applied to the underline when the input is focused | `{}` |
+| `--paper-input-container-underline-invalid` | Mixin applied to the underline when the input is invalid | `{}` |
 | `--paper-input-container-underline-disabled` | Mixin applied to the underline when the input is disabled | `{}` |
 | `--paper-input-prefix` | Mixin applied to the input prefix | `{}` |
 | `--paper-input-suffix` | Mixin applied to the input suffix | `{}` |
+|`--paper-input-container-add-on-invalid` | Mixin applied to the add-on when the input is invalid | `{}` |
 
 This element is `display:block` by default, but you can set the `inline` attribute to make it
 `display:inline-block`.

--- a/demo/index.html
+++ b/demo/index.html
@@ -140,6 +140,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </paper-input-container>
       </template>
     </demo-snippet>
+    
+    <h3>Inputs can have custom error styling</h3>
+    <demo-snippet>
+      <template>
+        <style is="custom-style">
+          .styled-error-input {
+            --paper-input-container-label-invalid: {
+              color: var(--paper-indigo-500);
+            };
+            --paper-input-container-underline-invalid: {
+              background: var(--paper-orange-500);
+            };
+            --paper-input-container-add-on-invalid: {
+              color: var(--paper-blue-grey-600);
+            };
+          }
+        </style>
+        <paper-input class="styled-error-input" label="this input requires some text" required auto-validate error-message="needs some text!"></paper-input>
+        <paper-input class="styled-error-input" label="this input requires letters only" auto-validate pattern="[a-zA-Z]*" error-message="letters only!"></paper-input>
+      </template>
+    </demo-snippet>
   </div>
 
   <script>

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -88,13 +88,16 @@ Custom property | Description | Default
 `--paper-input-container-disabled` | Mixin applied to the container when it's disabled | `{}`
 `--paper-input-container-label` | Mixin applied to the label | `{}`
 `--paper-input-container-label-focus` | Mixin applied to the label when the input is focused | `{}`
+`--paper-input-container-label-invalid` | Mixin applied to the label when the input is invalid | `{}`
 `--paper-input-container-label-floating` | Mixin applied to the label when floating | `{}`
 `--paper-input-container-input` | Mixin applied to the input | `{}`
 `--paper-input-container-underline` | Mixin applied to the underline | `{}`
 `--paper-input-container-underline-focus` | Mixin applied to the underline when the input is focused | `{}`
+`--paper-input-container-underline-invalid` | Mixin applied to the underline when the input is invalid | `{}`
 `--paper-input-container-underline-disabled` | Mixin applied to the underline when the input is disabled | `{}`
 `--paper-input-prefix` | Mixin applied to the input prefix | `{}`
 `--paper-input-suffix` | Mixin applied to the input suffix | `{}`
+`--paper-input-container-add-on-invalid` | Mixin applied to the add-on when the input is invalid | `{}`
 
 This element is `display:block` by default, but you can set the `inline` attribute to make it
 `display:inline-block`.
@@ -164,6 +167,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
         transition: transform 0.25s;
 
         @apply(--paper-transition-easing);
+        @apply(--paper-input-container-underline-invalid);
       }
 
       .unfocused-line {
@@ -250,6 +254,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-content.is-invalid ::content label,
       .input-content.is-invalid ::content .paper-input-label {
         color: var(--paper-input-container-invalid-color, --error-color);
+
+        @apply(--paper-input-container-label-invalid);
       }
 
       .input-content.label-is-hidden ::content label,
@@ -306,6 +312,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
 
       .add-on-content.is-invalid ::content * {
         color: var(--paper-input-container-invalid-color, --error-color);
+
+        @apply(--paper-input-container-add-on-invalid);
       }
 
       .add-on-content.is-highlighted ::content * {


### PR DESCRIPTION
I wanted to use the paper-input but not style the label, underline and add-on in the same color when invalid. In the current situation all three elements where all styled by the variable:
--paper-input-container-invalid-color

With these three new mixins the label, underline and add-on can be styled individually.

