### PR TITLE
support for multiple error messages (which are defined in validators)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "iron-autogrow-textarea": "PolymerElements/iron-autogrow-textarea#^1.0.0",
     "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
     "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
-    "iron-input": "PolymerElements/iron-input#^1.0.0",
+    "iron-input": "https://github.com/tlouisse/iron-input.git#feature/multipleValidators",
     "paper-styles": "PolymerElements/paper-styles#^1.1.4",
     "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0"
   },
@@ -42,10 +42,16 @@
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
-    "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^1.0.0",
+    "iron-validatable-behavior": "https://github.com/tlouisse/iron-validatable-behavior.git",
+    "iron-validator-behavior": "https://github.com/tlouisse/iron-validator-behavior.git",
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+  },
+  "resolutions": {
+    "iron-validatable-behavior": "feature/multipleValidators",
+    "iron-validator-behavior": "feature/multipleValidators",
+    "iron-input": "feature/multipleValidators"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,6 +30,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../paper-input.html">
   <link rel="import" href="../paper-textarea.html">
   <link rel="import" href="ssn-input.html">
+  <link rel="import" href="validators/no-cats.html">
+  <link rel="import" href="validators/no-catfishes.html">
 
   <style is="custom-style" include="demo-pages-shared-styles">
     paper-input {
@@ -110,6 +112,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <paper-input label="this input requires letters only" auto-validate pattern="[a-zA-Z]*" error-message="letters only!"></paper-input>
         <paper-input label="this input will only let you type letters" auto-validate allowed-pattern="[a-zA-Z]"></paper-input>
         <paper-input id="inputForValidation" required label="this input is manually validated" pattern="[a-zA-Z]*" error-message="letters only!"></paper-input>
+        <paper-input label="this input has multiple validators (no-cats + no-catfishes)" validator="no-cats no-catfishes" auto-validate></paper-input>
         <button onclick="validate()">Validate!</button>
       </template>
     </demo-snippet>

--- a/demo/validators/no-catfishes.html
+++ b/demo/validators/no-catfishes.html
@@ -1,0 +1,37 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
+
+<script>
+
+    Polymer({
+
+        is: 'no-catfishes',
+
+        properties: {
+            message: {
+                type: String,
+                value: 'No cat(fish(es)) allowed'
+            }
+        },
+
+        behaviors: [
+            Polymer.IronValidatorBehavior
+        ],
+
+        validate: function (value) {
+            return !value.match(/cat(fish|fishes)?$/);
+        }
+
+    });
+
+</script>

--- a/demo/validators/no-cats.html
+++ b/demo/validators/no-cats.html
@@ -1,0 +1,37 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
+
+<script>
+
+    Polymer({
+
+        is: 'no-cats',
+
+        properties: {
+            message: {
+                type: String,
+                value: 'No cat(s) allowed'
+            }
+        },
+
+        behaviors: [
+            Polymer.IronValidatorBehavior
+        ],
+
+        validate: function (value) {
+            return !value.match(/cats?$/);
+        }
+
+    });
+
+</script>

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -352,6 +352,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
+       * The id used to connect the validator instance implementing IronValidatableBehavior(having a 'for' property)
+       * to the validatable. This is useful for validator instances containing custom messages.
+       * If you're using PaperInputBehavior to implement your own paper-input-like
+       * element, bind this to the `<input is="iron-input">`'s `validatable-id` property.
+       */
+      validatableId: {
+          type: String
+      },
+
+      /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
        * element, bind this to the`<input is="iron-input">`'s `multiple` property,
        * used with type=file.

--- a/paper-input.html
+++ b/paper-input.html
@@ -142,12 +142,22 @@ style this element.
         autosave$="[[autosave]]"
         results$="[[results]]"
         accept$="[[accept]]"
-        multiple$="[[multiple]]">
+        multiple$="[[multiple]]"
+        errors="{{errors}}"
+        validatable-id="[[validatableId]]">
 
       <content select="[suffix]"></content>
 
       <template is="dom-if" if="[[errorMessage]]">
         <paper-input-error aria-live="assertive">[[errorMessage]]</paper-input-error>
+      </template>
+
+      <template is="dom-if" if="[[_showErrors(errors.splices)]]">
+        <paper-input-error aria-live="assertive" hidden$="">
+          <template is="dom-repeat" items="[[errors]]" filter="_showHighestPrio">
+            <div>[[item.message]]</div>
+          </template>
+        </paper-input-error>
       </template>
 
       <template is="dom-if" if="[[charCounter]]">
@@ -165,6 +175,20 @@ style this element.
     behaviors: [
       Polymer.IronFormElementBehavior,
       Polymer.PaperInputBehavior
-    ]
+    ],
+
+    /**
+     * Makes sure only error messages with the highest priority are shown.
+     * @param {Object} item The error object to be filtered out.
+     * @return {boolean} True if `value` has the highest priority.
+     */
+    _showHighestPrio: function (item) {
+      return item.priority < 1;
+    },
+
+    _showErrors: function(errors) {
+      return !this.errorMessage && errors;
+    }
+
   });
 </script>

--- a/test/index.html
+++ b/test/index.html
@@ -16,11 +16,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     WCT.loadSuites([
       'paper-input.html',
+      'paper-input_validations.html',
       'paper-textarea.html',
       'paper-input-container.html',
       'paper-input-error.html',
       'paper-input-char-counter.html',
       'paper-input.html?dom=shadow',
+      'paper-input_validations.html?dom=shadow',
       'paper-textarea.html?dom=shadow',
       'paper-input-container.html?dom=shadow',
       'paper-input-error.html?dom=shadow',

--- a/test/paper-input_validations.html
+++ b/test/paper-input_validations.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+    <title>paper-input tests</title>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../iron-test-helpers/test-helpers.js"></script>
+    <script src="../../iron-test-helpers/mock-interactions.js"></script>
+
+    <link rel="import" href="../paper-input.html">
+    <link rel="import" href="validators/letters-only.html">
+    <link rel="import" href="validators/cats-only.html">
+
+</head>
+<body>
+
+<test-fixture id="validatable">
+    <template>
+        <paper-input validator="cats-only"></paper-input>
+    </template>
+</test-fixture>
+
+<test-fixture id="error-message">
+    <template>
+        <paper-input pattern="[a-zA-Z]*" error-message="override error"></paper-input>
+    </template>
+</test-fixture>
+
+<test-fixture id="multiple-errors">
+    <template>
+        <paper-input validator="cats-only letters-only"></paper-input>
+    </template>
+</test-fixture>
+
+<script>
+
+    suite('validatable id', function () {
+
+        test('validatable id is passed to input field', function () {
+            var node = fixture('validatable');
+            Polymer.dom(node).flush(function () {
+                assert.equal(node.$.input.validatableId, node.validatableId);
+            });
+        });
+
+    });
+
+    suite('error messages', function () {
+
+        test('show error message defined in external validator', function (done) {
+            var input = fixture('validatable');
+            input.value = 'foobar';
+            input.validate();
+            flush(function () {
+                var error = Polymer.dom(input.root).querySelector('paper-input-error').textContent;
+                assert.include(error, 'No cats');
+                done();
+            });
+        });
+
+        test('always show error message defined via error-message attribute', function (done) {
+            var input = fixture('error-message');
+            input.value = '123';
+            input.validate();
+            flush(function () {
+                var error = Polymer.dom(input.root).querySelector('paper-input-error').textContent;
+                assert.equal(error.trim(), 'override error', 'letters only!');
+                done();
+            });
+        });
+
+        test('show error message with top priority', function (done) {
+            var input = fixture('multiple-errors');
+            input.value = '123';
+            input.validate();
+            flush(function () {
+                var error = Polymer.dom(input.root).querySelector('paper-input-error').textContent;
+                assert.include(error, 'No cats');
+                done();
+            });
+        });
+
+    });
+
+</script>
+
+</body>
+</html>

--- a/test/validators/cats-only.html
+++ b/test/validators/cats-only.html
@@ -1,0 +1,37 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
+
+    <script>
+
+    Polymer({
+
+        is: 'cats-only',
+
+        behaviors: [
+            Polymer.IronValidatorBehavior
+        ],
+
+        properties: {
+            message: {
+                type: String,
+                value: 'No cats'
+            }
+        },
+
+        validate: function (value) {
+            return value === 'cats';
+        }
+
+    });
+
+</script>

--- a/test/validators/letters-only.html
+++ b/test/validators/letters-only.html
@@ -1,0 +1,37 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
+
+    <script>
+
+    Polymer({
+
+        is: 'letters-only',
+
+        behaviors: [
+            Polymer.IronValidatorBehavior
+        ],
+
+        properties: {
+            message: {
+                type: String,
+                value: 'Only letters, please'
+            }
+        },
+
+        validate: function (value) {
+            return !value || value.match(/^[a-zA-Z]*$/) !== null;
+        }
+
+    });
+
+</script>


### PR DESCRIPTION

Currently, it's not possible to use multiple validators on an input.

Also see:
- https://github.com/PolymerElements/paper-input/issues/289
- https://github.com/PolymerElements/iron-input/issues/53

With this pull request, it will become possible to add multiple validators to elements implementing the validatable behavior, without having to write a new custom validator that combines functionality of other validators. 

Along with this functionality, the following will be supported:
- custom messages: 
	- stored in validators (so there's a single source of truth, resulting in consistency between forms and less development work)
	- support for multiple error messages, ordered by priority (the most important message will be shown by the paper-input)
- support for native validators('required', 'max', 'min', 'step', 'maxlength', 'minlength', 'pattern', 'emailtype'(type=email) and 'urltype' (type=url))
- automatic instantiating of custom validators 
- possibility to connect unique instances of a validator to a validatable-element (when overriding of the default message will be needed)

Everything is tested for backwards compatibility. All tests have run in chrome 51, firefox 46, OS X 10.9 safari 7, OS X 10.10 safari 8, OS X 10.11 safari 9, Windows 7 IE 10, Windows 8.1 IE 11, Windows 10 microsoftedge, Android 4.3, Android 4.4, Android 5, Android 6, iOS 7, iOS 8, iOS 9.3.

Note that, since the validation functionality is located in different repositories, the above functionality will contain pull requests in the following repositories:
- iron-validator-behavior
- iron-validable-behavior
- iron-input
- paper-input

The link below shows an example of what would be the benefit of the old vs. the new situation.
It makes clear what the API will look like and how little code will be needed to achieve the same in the new situation.

https://tlouisse.github.io/iron-validatable-behavior/components/iron-validatable-behavior/demo/
