### PR TITLE
Add CSS mixing for webkit spinner

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -90,6 +90,7 @@ Custom property | Description | Default
 `--paper-input-container-label-focus` | Mixin applied to the label when the input is focused | `{}`
 `--paper-input-container-label-floating` | Mixin applied to the label when floating | `{}`
 `--paper-input-container-input` | Mixin applied to the input | `{}`
+`--paper-input-container-input-webkit-spinner` | Mixin applied to the webkit spinner | `{}`
 `--paper-input-container-underline` | Mixin applied to the underline | `{}`
 `--paper-input-container-underline-focus` | Mixin applied to the underline when the input is focused | `{}`
 `--paper-input-container-underline-disabled` | Mixin applied to the underline when the input is disabled | `{}`
@@ -276,6 +277,11 @@ This element is `display:block` by default, but you can set the `inline` attribu
 
         @apply(--paper-font-subhead);
         @apply(--paper-input-container-input);
+      }
+
+      .input-content ::content input::-webkit-outer-spin-button,
+      .input-content ::content input::-webkit-inner-spin-button {
+        @apply(--paper-input-container-input-webkit-spinner);
       }
 
       ::content [prefix] {


### PR DESCRIPTION
Was facing the same issue and saw there was already an issue open for it. I have tested it in my application and it is working perfectly with:

``` css
paper-input[type="number"] {
  --paper-input-container-input-webkit-spinner: {
    -webkit-appearance: none;
    margin: 0;
  }
}
```

Fixes #279
