### PR TITLE
pass validator attribute to iron-autogrow-textarea make possible to use custom validator

### DIFF
--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -56,6 +56,7 @@ style this element.
       <iron-autogrow-textarea id="input" class="paper-input-input"
         bind-value="{{value}}"
         invalid="{{invalid}}"
+        validator$="[[validator]]"
         disabled$="[[disabled]]"
         autocomplete$="[[autocomplete]]"
         autofocus$="[[autofocus]]"


### PR DESCRIPTION
pass the validator attribute to iron-autogrow-textarea make possible to use custom validator
