### PR TITLE
Update paper-input.html

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -197,7 +197,7 @@ style this element.
       Polymer.PaperInputBehavior
     ],
 
-    registered: function() {
+    created: function() {
       // These types have some default placeholder text; overlapping
       // the label on top of it looks terrible. Auto-float the label in this case.
       this._typesThatHaveText = ["date", "datetime", "datetime-local", "month",


### PR DESCRIPTION
Fixes the following error:

![error](https://i.imgur.com/jdF7JHE.png)

Note: I encountered a similar error in [iron-a11y-keys-behavior](https://github.com/PolymerElements/iron-a11y-keys-behavior/pull/59). I assume `registered` callback doesn't happen at the same time as in 1.0.
