### PR TITLE
Implementat @apply mixins to control styling

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -90,6 +90,8 @@ Custom property | Description | Default
 `--paper-input-container-label-focus` | Mixin applied to the label when the input is focused | `{}`
 `--paper-input-container-label-floating` | Mixin applied to the label when floating | `{}`
 `--paper-input-container-input` | Mixin applied to the input | `{}`
+`--paper-input-container-input-focus` | Mixin applied to the input | `{}`
+`--paper-input-container-input-invalid` | Mixin applied to the input | `{}`
 `--paper-input-container-input-webkit-spinner` | Mixin applied to the webkit spinner | `{}`
 `--paper-input-container-underline` | Mixin applied to the underline | `{}`
 `--paper-input-container-underline-focus` | Mixin applied to the underline when the input is focused | `{}`
@@ -275,6 +277,20 @@ This element is `display:block` by default, but you can set the `inline` attribu
 
         @apply(--paper-font-subhead);
         @apply(--paper-input-container-input);
+      }
+
+	  .input-content ::content input:focus,
+      .input-content ::content textarea:focus,
+      .input-content ::content iron-autogrow-textarea:focus,
+      .input-content ::content .paper-input-input:focus {
+        @apply(--paper-input-container-input-focus);
+      }
+
+	  .input-content ::content input[invalid],
+      .input-content ::content textarea[invalid],
+      .input-content ::content iron-autogrow-textarea[invalid],
+      .input-content ::content .paper-input-input[invalid] {
+        @apply(--paper-input-container-input-invalid);
       }
 
       .input-content ::content input::-webkit-outer-spin-button,

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -279,17 +279,17 @@ This element is `display:block` by default, but you can set the `inline` attribu
         @apply(--paper-input-container-input);
       }
 
-      .input-content ::content input:focus,
-      .input-content ::content textarea:focus,
-      .input-content ::content iron-autogrow-textarea:focus,
-      .input-content ::content .paper-input-input:focus {
+      .input-content.focused ::content input,
+      .input-content.focused ::content textarea,
+      .input-content.focused ::content iron-autogrow-textarea,
+      .input-content.focused ::content .paper-input-input {
         @apply(--paper-input-container-input-focus);
       }
 
-      .input-content ::content input[invalid],
-      .input-content ::content textarea[invalid],
-      .input-content ::content iron-autogrow-textarea[invalid],
-      .input-content ::content .paper-input-input[invalid] {
+      .input-content.is-invalid ::content input,
+      .input-content.is-invalid ::content textarea,
+      .input-content.is-invalid ::content iron-autogrow-textarea,
+      .input-content.is-invalid ::content .paper-input-input {
         @apply(--paper-input-container-input-invalid);
       }
 
@@ -610,12 +610,21 @@ This element is `display:block` by default, but you can set the `inline` attribu
           if (label) {
             this.$.labelAndInputContainer.style.position = 'relative';
           }
+		  if (invalid) {
+            cls += ' is-invalid';
+          }
         }
       } else {
         if (_inputHasContent) {
           cls += ' label-is-hidden';
         }
+		if (invalid) {
+		  cls += ' is-invalid';
+		}
       }
+	  if (focused) {
+		  cls += ' focused';
+	  }
       return cls;
     },
 

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -622,9 +622,9 @@ This element is `display:block` by default, but you can set the `inline` attribu
           cls += ' is-invalid';
         }
       }
-	  if (focused) {
+      if (focused) {
         cls += ' focused';
-	  }
+      }
       return cls;
     },
 

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -90,8 +90,8 @@ Custom property | Description | Default
 `--paper-input-container-label-focus` | Mixin applied to the label when the input is focused | `{}`
 `--paper-input-container-label-floating` | Mixin applied to the label when floating | `{}`
 `--paper-input-container-input` | Mixin applied to the input | `{}`
-`--paper-input-container-input-focus` | Mixin applied to the input | `{}`
-`--paper-input-container-input-invalid` | Mixin applied to the input | `{}`
+`--paper-input-container-input-focus` | Mixin applied to the input when focused | `{}`
+`--paper-input-container-input-invalid` | Mixin applied to the input when invalid | `{}`
 `--paper-input-container-input-webkit-spinner` | Mixin applied to the webkit spinner | `{}`
 `--paper-input-container-underline` | Mixin applied to the underline | `{}`
 `--paper-input-container-underline-focus` | Mixin applied to the underline when the input is focused | `{}`
@@ -279,14 +279,14 @@ This element is `display:block` by default, but you can set the `inline` attribu
         @apply(--paper-input-container-input);
       }
 
-	  .input-content ::content input:focus,
+      .input-content ::content input:focus,
       .input-content ::content textarea:focus,
       .input-content ::content iron-autogrow-textarea:focus,
       .input-content ::content .paper-input-input:focus {
         @apply(--paper-input-container-input-focus);
       }
 
-	  .input-content ::content input[invalid],
+      .input-content ::content input[invalid],
       .input-content ::content textarea[invalid],
       .input-content ::content iron-autogrow-textarea[invalid],
       .input-content ::content .paper-input-input[invalid] {

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -610,7 +610,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
           if (label) {
             this.$.labelAndInputContainer.style.position = 'relative';
           }
-		  if (invalid) {
+          if (invalid) {
             cls += ' is-invalid';
           }
         }
@@ -618,12 +618,12 @@ This element is `display:block` by default, but you can set the `inline` attribu
         if (_inputHasContent) {
           cls += ' label-is-hidden';
         }
-		if (invalid) {
-		  cls += ' is-invalid';
-		}
+        if (invalid) {
+          cls += ' is-invalid';
+        }
       }
 	  if (focused) {
-		  cls += ' focused';
+        cls += ' focused';
 	  }
       return cls;
     },

--- a/paper-input.html
+++ b/paper-input.html
@@ -72,10 +72,12 @@ style this element.
     <style>
       :host {
         display: block;
+        @apply(--paper-input);
       }
 
       :host([focused]) {
         outline: none;
+        @apply(--paper-input-focused);
       }
 
       :host([hidden]) {

--- a/paper-input.html
+++ b/paper-input.html
@@ -72,12 +72,10 @@ style this element.
     <style>
       :host {
         display: block;
-        @apply(--paper-input);
       }
 
       :host([focused]) {
         outline: none;
-        @apply(--paper-input-focused);
       }
 
       :host([hidden]) {

--- a/test/paper-input-container.html
+++ b/test/paper-input-container.html
@@ -103,6 +103,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="required-validate">
+    <template>
+      <paper-input-container>
+        <label id="l">label</label>
+        <input is="iron-input" id="i" required>
+      </paper-input-container>
+    </template>
+  </test-fixture>
+
   <letters-only></letters-only>
 
   <test-fixture id="auto-validate-validator">
@@ -244,6 +253,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
+      test('focused class added to input content', function(done) {
+        var container = fixture('basic');
+        var input = Polymer.dom(container).querySelector('#i');
+        var inputContent = Polymer.dom(container.root).querySelector('.input-content');
+        assert.isFalse(inputContent.classList.contains('focused'), 'input content does not have class "focused" when input is not focused');
+        MockInteractions.focus(input);
+        requestAnimationFrame(function() {
+          assert.isTrue(inputContent.classList.contains('focused'), 'input content has class "focused" when input is focused');
+          done();
+        });
+      });
+
     });
 
     suite('validation', function() {
@@ -292,6 +313,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isTrue(container.invalid, 'invalid is true');
         assert.isTrue(inputContent.classList.contains('is-invalid'), 'label has invalid styling when input is invalid');
         assert.isTrue(line.classList.contains('is-invalid'), 'underline has invalid styling when input is invalid');
+      });
+
+      test('styled when the input is manually validated and required', function() {
+        var container = fixture('required-validate');
+        var input = Polymer.dom(container).querySelector('#i');
+        var inputContent = Polymer.dom(container.root).querySelector('.input-content');
+        assert.isFalse(container.invalid, 'invalid is false');
+        input.validate();
+        assert.isTrue(container.invalid, 'invalid is true');
+        assert.isTrue(inputContent.classList.contains('is-invalid'), 'input content has is-invalid class');
       });
 
     });


### PR DESCRIPTION
Surface default (`:host`) and focused (`:host([focused])`) targeted mixin implementations for the component.

references #463