### PR TITLE
label highlight should still be applied if the label doesn't float

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -586,8 +586,6 @@ This element is `display:block` by default, but you can set the `inline` attribu
 
           if (invalid) {
             cls += ' is-invalid';
-          } else if (focused) {
-            cls += " label-is-highlighted";
           }
         } else {
           // When the label is not floating, it should overlap the input element.
@@ -599,6 +597,9 @@ This element is `display:block` by default, but you can set the `inline` attribu
         if (_inputHasContent) {
           cls += ' label-is-hidden';
         }
+      }
+      if (focused) {
+        cls += " label-is-highlighted";
       }
       return cls;
     },


### PR DESCRIPTION
PR to master branch as requested by @notwaldorf (see #460)
The issue exists in both 1.7 and 2.0-preview

As per this file's comments:
```
`--paper-input-container-focus-color` | Label and underline color when the input is focused | `--primary-color`
```
Currently this is never applied due to missing `label-is-highlighted` class on `#labelAndInputContainer` where `[label-no-float]` is applied to the host.

This PR always applies `label-is-highlighted` class to `#labelAndInputContainer` if the input is focused, regardless of float state.