### PR TITLE
Move css mixins to bottom of the rules-block in paper-input-error element

### DIFF
--- a/paper-input-error.html
+++ b/paper-input-error.html
@@ -38,14 +38,14 @@ Custom property | Description | Default
       :host {
         display: inline-block;
         visibility: hidden;
+        position: absolute;
+        left:0;
+        right:0;
 
         color: var(--paper-input-container-invalid-color, var(--error-color));
 
         @apply --paper-font-caption;
         @apply --paper-input-error;
-        position: absolute;
-        left:0;
-        right:0;
       }
 
       :host([invalid]) {


### PR DESCRIPTION
This change allows user to set the position css property of the `paper-input-error element`.