### PR TITLE
Make _beforeRegister idempotent

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -262,10 +262,12 @@ style this element.
 
     _beforeRegister: function() {
       var template = Polymer.DomModule.import('paper-input', 'template');
-      var version = Polymer.Element ? 'v1' : 'v0';
-      var inputTemplate = Polymer.DomModule.import('paper-input', 'template#' + version);
       var inputPlaceholder = template.content.querySelector('#template-placeholder');
-      inputPlaceholder.parentNode.replaceChild(inputTemplate.content, inputPlaceholder);
+      if (inputPlaceholder) {
+        var version = Polymer.Element ? 'v1' : 'v0';
+        var inputTemplate = Polymer.DomModule.import('paper-input', 'template#' + version);
+        inputPlaceholder.parentNode.replaceChild(inputTemplate.content, inputPlaceholder);
+      }
     },
 
     /**


### PR DESCRIPTION
Fixes paper-input running against polymer#master.

This issue is occurring because `_beforeRegister` is currently called twice. Once the `registered` method is removed this problem goes away. We can't remove `registered` yet because the commit reintroducing `beforeRegister` has not been versioned.

This PR simply checks if the inputPlaceholder has been replaced already by checking for its existence.