### PR TITLE
Added mixin to be applied on input:disabled

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -99,6 +99,7 @@ Custom property | Description | Default
 `--paper-input-container-label-focus` | Mixin applied to the label when the input is focused | `{}`
 `--paper-input-container-label-floating` | Mixin applied to the label when floating | `{}`
 `--paper-input-container-input` | Mixin applied to the input | `{}`
+`--paper-input-container-input-disabled` | Mixin applied to the input when the component is disabled | `{}`
 `--paper-input-container-input-focus` | Mixin applied to the input when focused | `{}`
 `--paper-input-container-input-invalid` | Mixin applied to the input when invalid | `{}`
 `--paper-input-container-input-webkit-spinner` | Mixin applied to the webkit spinner | `{}`

--- a/paper-input.html
+++ b/paper-input.html
@@ -102,6 +102,10 @@ style this element.
         @apply --paper-input-container-input;
       }
 
+      input:disabled {
+        @apply --paper-input-container-input-disabled;
+      }
+
       input::-webkit-outer-spin-button,
       input::-webkit-inner-spin-button {
         @apply --paper-input-container-input-webkit-spinner;


### PR DESCRIPTION
Fixes #539

This fixes #539 adding a mixin `--paper-input-container-input-disabled` to be applied on the input element when the `paper-input` is disabled.