### PR TITLE
Pipe label through to aria-labels

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -397,8 +397,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
-      this._updateAriaLabelledBy();
-
       // In the 2.0 version of the element, this is handled in `onIronInputReady`,
       // i.e. after the native input has finished distributing. In the 1.0 version,
       // the input is in the shadow tree, so it's already available.
@@ -496,22 +494,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _computeAlwaysFloatLabel: function(alwaysFloatLabel, placeholder) {
       return placeholder || alwaysFloatLabel;
-    },
-
-    _updateAriaLabelledBy: function() {
-      var label = Polymer.dom(this.root).querySelector('label');
-      if (!label) {
-        this._ariaLabelledBy = '';
-        return;
-      }
-      var labelledBy;
-      if (label.id) {
-        labelledBy = label.id;
-      } else {
-        labelledBy = 'paper-input-label-' + Polymer.PaperInputHelper.NextLabelID++;
-        label.id = labelledBy;
-      }
-      this._ariaLabelledBy = labelledBy;
     },
 
     _onChange:function(event) {

--- a/paper-input.html
+++ b/paper-input.html
@@ -145,7 +145,7 @@ style this element.
 
       <slot name="prefix" slot="prefix"></slot>
 
-      <label hidden$="[[!label]]" aria-hidden="true" for="input" slot="label">[[label]]</label>
+      <label hidden$="[[!label]]" aria-hidden="true" slot="label">[[label]]</label>
 
       <span id="template-placeholder"></span>
 
@@ -168,7 +168,7 @@ style this element.
    -->
   <template id="v0">
     <input is="iron-input" id="input" slot="input"
-        aria-labelledby$="[[_ariaLabelledBy]]"
+        aria-label$="[[label]]"
         aria-describedby$="[[_ariaDescribedBy]]"
         disabled$="[[disabled]]"
         title$="[[title]]"
@@ -211,7 +211,7 @@ style this element.
         invalid="{{invalid}}"
         validator="[[validator]]">
       <input id="nativeInput"
-        aria-labelledby$="[[_ariaLabelledBy]]"
+        aria-label$="[[label]]"
         aria-describedby$="[[_ariaDescribedBy]]"
         disabled$="[[disabled]]"
         title$="[[title]]"

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -55,10 +55,10 @@ style this element.
         disabled$="[[disabled]]"
         invalid="[[invalid]]">
 
-      <label hidden$="[[!label]]" aria-hidden="true" for="input" slot="label">[[label]]</label>
+      <label hidden$="[[!label]]" aria-hidden="true" slot="label">[[label]]</label>
 
       <iron-autogrow-textarea id="input" class="paper-input-input" slot="input"
-        aria-labelledby$="[[_ariaLabelledBy]]"
+        label="[[label]]"
         aria-describedby$="[[_ariaDescribedBy]]"
         bind-value="{{value}}"
         invalid="{{invalid}}"
@@ -100,11 +100,6 @@ style this element.
     ],
 
     properties: {
-      _ariaLabelledBy: {
-        observer: '_ariaLabelledByChanged',
-        type: String
-      },
-
       _ariaDescribedBy: {
         observer: '_ariaDescribedByChanged',
         type: String
@@ -134,10 +129,6 @@ style this element.
        type: Number,
        value: 0
       }
-    },
-
-    _ariaLabelledByChanged: function(ariaLabelledBy) {
-      this.$.input.textarea.setAttribute('aria-labelledby', ariaLabelledBy);
     },
 
     _ariaDescribedByChanged: function(ariaDescribedBy) {


### PR DESCRIPTION
Pipe label through as `aria-label`. This (i think) removes the need for the `updateAriaLabelledby` code. Specially this change is intended to fix an issue with paper-textarea. Because there is a shadow boundary between the textarea and paper-textarea, using aria-labelledby doesn't work. This PR depends on https://github.com/PolymerElements/iron-autogrow-textarea/pull/108 being merged first.