### PR TITLE
Fix a typo in the documentation of paper-input-container.

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -28,7 +28,7 @@ For example:
       // In Polymer 1.0, you would use `<input is="iron-input" slot="input">` instead of the above.
     </paper-input-container>
 
-You can style the nested <input> however you want; if you want it to look like a
+You can style the nested `<input>` however you want; if you want it to look like a
 Material Design input, you can style it with the --paper-input-container-shared-input-style mixin.
 
 Do not wrap `<paper-input-container>` around elements that already include it, such as `<paper-input>`.


### PR DESCRIPTION
There are missing quotes around an HTML tag in paper-input-container documentation, which is causing the HTML tag be interpreted on browsers.