### PR TITLE
Remove extra margin from Safari user agent stylesheet

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -85,6 +85,7 @@ style this element.
         position: relative; /* to make a stacking context */
         outline: none;
         box-shadow: none;
+        margin: 0;
         padding: 0;
         width: 100%;
         max-width: 100%;

--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -296,11 +296,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // every time a paper-input is focused.
       test('focus events fired on host element', function(done) {
         // Mutation observer is async, so wait one tick.
+        var testThis = this;
         Polymer.Base.async(function() {
           ensureDocumentHasFocus();
           // If the document doesn't have focus, we can't test focus.
           if (!window.top.document.hasFocus()) {
-            this.skip();
+            testThis.skip();
           }
           input.focus();
           assert(input.focused, 'input is focused');


### PR DESCRIPTION
Safari's user agent stylesheet adds a 4px margin-top and margin-bottom for inputs. This removes that and fixes #520 

Left is Chrome, right is Safari. Before:
![screen shot 2017-09-27 at 9 04 33 am](https://user-images.githubusercontent.com/14365924/30918415-1a7467b4-a364-11e7-8696-ecea1b7e7371.png)

After:
![screen shot 2017-09-27 at 9 14 54 am](https://user-images.githubusercontent.com/14365924/30918502-59b65fa4-a364-11e7-9921-4011ea9d2740.png)


Only affects `<paper-input>`, `<paper-textarea>` is fine.
