### PR TITLE
master - fixes #352 safari hack: focusing input w/ 0 height

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -237,6 +237,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
         transition: transform 0.25s, width 0.25s;
         -webkit-transform-origin: left top;
         transform-origin: left top;
+        /* Fix for safari not focusing 0-height date/time inputs with -webkit-apperance: none; */
+        min-height: 1px;
 
         @apply --paper-font-common-nowrap;
         @apply --paper-font-subhead;


### PR DESCRIPTION
Tested on iPhone 5S/iOS 11.0.2