### PR TITLE
fix label width in rtl; add :dir for polymer 2

### DIFF
--- a/paper-input-char-counter.html
+++ b/paper-input-char-counter.html
@@ -45,6 +45,7 @@ Custom property | Description | Default
         display: none !important;
       }
 
+      :host(:dir(rtl)),
       :host-context([dir="rtl"]) {
         float: left;
       }

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -121,6 +121,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       :host {
         display: block;
         padding: 8px 0;
+        overflow: hidden;
 
         --paper-input-container-shared-input-style: {
           position: relative; /* to make a stacking context */
@@ -259,12 +260,10 @@ This element is `display:block` by default, but you can set the `inline` attribu
         @apply --paper-input-container-label-floating;
       }
 
+      :host(:dir(rtl)) .input-content.label-is-floating ::slotted(label),
+      :host(:dir(rtl)) .input-content.label-is-floating ::slotted(.paper-input-label),
       :host-context([dir="rtl"]) .input-content.label-is-floating ::slotted(label),
       :host-context([dir="rtl"]) .input-content.label-is-floating ::slotted(.paper-input-label) {
-        /* TODO(noms): Figure out why leaving the width at 133% before the animation
-         * actually makes
-         * it wider on the right side, not left side, as you would expect in RTL */
-        width: 100%;
         -webkit-transform-origin: right top;
         transform-origin: right top;
       }
@@ -289,7 +288,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-content ::slotted(iron-input) {
         @apply --paper-input-container-shared-input-style;
       }
-      
+
       .input-content ::slotted(input),
       .input-content ::slotted(textarea),
       .input-content ::slotted(iron-autogrow-textarea),
@@ -302,7 +301,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-content ::slotted(input)::-webkit-inner-spin-button {
         @apply --paper-input-container-input-webkit-spinner;
       }
-      
+
       .input-content.focused ::slotted(input),
       .input-content.focused ::slotted(textarea),
       .input-content.focused ::slotted(iron-autogrow-textarea),
@@ -316,7 +315,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-content.is-invalid ::slotted(.paper-input-input) {
         @apply --paper-input-container-input-invalid;
       }
-      
+
       .prefix ::slotted(*) {
         display: inline-block;
         @apply --paper-font-subhead;


### PR DESCRIPTION
- fixes #593: there was a TODO from like a year ago that made the effective width of the floated label in RTL smaller.
- Added `:dir` selectors so that this actually works in Polymer 2 with the polyfill (it doesn't on master)

There seems to be a separate bug where in Polymer 2 this still doesn't look perfectly right on Safari (the label is offset weirdly), but I am suspicious that's unrelated and a polyfill problem. 