### PR TITLE
Added a mixin for calendar picker indicator for date type input

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -104,6 +104,7 @@ Custom property | Description | Default
 `--paper-input-container-input-invalid` | Mixin applied to the input when invalid | `{}`
 `--paper-input-container-input-webkit-spinner` | Mixin applied to the webkit spinner | `{}`
 `--paper-input-container-input-webkit-clear` | Mixin applied to the webkit clear button | `{}`
+`--paper-input-container-input-webkit-calendar-picker-indicator` | Mixin applied to the webkit calendar picker indicator | `{}`
 `--paper-input-container-ms-clear` | Mixin applied to the Internet Explorer clear button | `{}`
 `--paper-input-container-underline` | Mixin applied to the underline | `{}`
 `--paper-input-container-underline-focus` | Mixin applied to the underline when the input is focused | `{}`

--- a/paper-input.html
+++ b/paper-input.html
@@ -123,6 +123,10 @@ Custom property | Description | Default
         @apply --paper-input-container-input-webkit-clear;
       }
 
+      input::-webkit-calendar-picker-indicator {
+        @apply --paper-input-container-input-webkit-calendar-picker-indicator;
+      }
+
       input::-webkit-input-placeholder {
         color: var(--paper-input-container-color, var(--secondary-text-color));
       }


### PR DESCRIPTION
With ::shadow soon to be no longer supported in Chrome, I needed another way to access the calendar picker indicator. This change makes it consistent with the other two icons alongside it, the clear and spin buttons.