### PR TITLE
Fix overflow:hidden bug I introduced in the previous PR 

### DIFF
--- a/paper-input-char-counter.html
+++ b/paper-input-char-counter.html
@@ -45,8 +45,7 @@ Custom property | Description | Default
         display: none !important;
       }
 
-      :host(:dir(rtl)),
-      :host-context([dir="rtl"]) {
+      :host(:dir(rtl)) {
         float: left;
       }
     </style>

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -259,9 +259,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       }
 
       :host(:dir(rtl)) .input-content.label-is-floating ::slotted(label),
-      :host(:dir(rtl)) .input-content.label-is-floating ::slotted(.paper-input-label),
-      :host-context([dir="rtl"]) .input-content.label-is-floating ::slotted(label),
-      :host-context([dir="rtl"]) .input-content.label-is-floating ::slotted(.paper-input-label) {
+      :host(:dir(rtl)) .input-content.label-is-floating ::slotted(.paper-input-label) {
         right: 0;
         left: auto;
         -webkit-transform-origin: right top;

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -121,7 +121,6 @@ This element is `display:block` by default, but you can set the `inline` attribu
       :host {
         display: block;
         padding: 8px 0;
-        overflow: hidden;
 
         --paper-input-container-shared-input-style: {
           position: relative; /* to make a stacking context */
@@ -230,7 +229,6 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-content ::slotted(.paper-input-label) {
         position: absolute;
         top: 0;
-        right: 0;
         left: 0;
         width: 100%;
         font: inherit;
@@ -264,6 +262,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
       :host(:dir(rtl)) .input-content.label-is-floating ::slotted(.paper-input-label),
       :host-context([dir="rtl"]) .input-content.label-is-floating ::slotted(label),
       :host-context([dir="rtl"]) .input-content.label-is-floating ::slotted(.paper-input-label) {
+        right: 0;
+        left: auto;
         -webkit-transform-origin: right top;
         transform-origin: right top;
       }

--- a/paper-input.html
+++ b/paper-input.html
@@ -61,6 +61,7 @@ See `Polymer.PaperInputContainer` for a list of custom properties used to
 style this element.
 
 The following custom properties and mixins are available for styling:
+
 Custom property | Description | Default
 ----------------|-------------|----------
 `--paper-input-container-ms-clear` | Mixin applied to the Internet Explorer reveal button (the eyeball) | {}


### PR DESCRIPTION
Fixes #597, fixes #593 again.

Previous PR on this topic #594 did a bad (I did the bad). It added `overflow:hidden` which actually cut off the input and made it look like this:
![screen shot 2017-12-05 at 4 54 38 pm](https://user-images.githubusercontent.com/1369170/33640096-6994e5b6-d9e3-11e7-93a7-320e14dc22d9.png)

This PR correctly fixes the original RTL problem (which was that the label-come-down-from-floating-to-not-floating animation overflowed in the container) by correctly setting the overflow direction (which is backwards, thanks @bicknellr for spotting that)

Not floated (ltr and rtl):
![screen shot 2017-12-05 at 5 35 37 pm](https://user-images.githubusercontent.com/1369170/33640134-9884b61c-d9e3-11e7-8f40-7ec1ca9c32d8.png)

Floated:
![screen shot 2017-12-05 at 5 35 43 pm](https://user-images.githubusercontent.com/1369170/33640136-9d568a8a-d9e3-11e7-9aea-16d93dfb519c.png)

And as a bonus does the thing that @azakus said we should do which is just use `:dir` errwhere because it works in 1.0 as well.

It takes a village, fam.
