### PR TITLE
Allow CSS Mixins for focus and invalid states to apply to paper-input

### DIFF
--- a/paper-input.html
+++ b/paper-input.html
@@ -110,6 +110,14 @@ Custom property | Description | Default
         @apply --paper-input-container-input;
       }
 
+      input:focus {
+        @apply --paper-input-container-input-focus;
+      }
+
+      input:invalid {
+        @apply --paper-input-container-input-invalid;
+      }
+      
       input:disabled {
         @apply --paper-input-container-input-disabled;
       }


### PR DESCRIPTION
The --paper-input-container-input-focus and
--paper-input-container-input-invalid mixins do not get applied to the
input element within paper-input.