### PR TITLE
1.x: Generate unique IDs for the input in the shadow root

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -372,7 +372,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _inputId: {
         type: String,
-        value: ''
+        value: function () {
+          return 'input_' + ( Math.random().toString(36).substring(2) );
+        }
       }
 
     },
@@ -393,7 +395,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Returns a reference to the input element.
      */
     get inputElement() {
-      return this.querySelector('input');
+      return this.querySelector('.input-element');
     },
 
     /**
@@ -412,7 +414,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     attached: function() {
       this._updateAriaLabelledBy();
-      this._updateInputId();
 
       if (this.inputElement &&
           this._typesThatHaveText.indexOf(this.inputElement.type) !== -1) {
@@ -523,10 +524,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         label.id = labelledBy;
       }
       this._ariaLabelledBy = labelledBy;
-    },
-
-    _updateInputId: function () {
-      this._inputId = 'input_' + Polymer.PaperInputHelper.NextLabelID;
     },
 
     _onChange:function(event) {

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -19,6 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.PaperInputHelper = {};
   Polymer.PaperInputHelper.NextLabelID = 1;
   Polymer.PaperInputHelper.NextAddonID = 1;
+  Polymer.PaperInputHelper.NextInputID = 1;
 
   /**
    * Use `Polymer.PaperInputBehavior` to implement inputs with `<paper-input-container>`. This
@@ -368,6 +369,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _ariaLabelledBy: {
         type: String,
         value: ''
+      },
+
+      _inputId: {
+        type: String,
+        value: ''
       }
 
     },
@@ -388,7 +394,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Returns a reference to the input element.
      */
     get inputElement() {
-      return this.querySelector('.input-element');
+      if (!this.$) {
+        this.$ = {}
+      }
+      if (!this.$.input) {
+        this.$.input = this.$$('#'+this._inputId);
+      }
+      return this.$.input;
     },
 
     /**
@@ -406,6 +418,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
+      this._updateInputId();
       this._updateAriaLabelledBy();
 
       if (this.inputElement &&
@@ -517,6 +530,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         label.id = labelledBy;
       }
       this._ariaLabelledBy = labelledBy;
+    },
+
+    _updateInputId: function() {
+      this._inputId =  'input-' + Polymer.PaperInputHelper.NextInputID++;
     },
 
     _onChange:function(event) {

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -368,13 +368,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _ariaLabelledBy: {
         type: String,
         value: ''
-      },
-
-      _inputId: {
-        type: String,
-        value: function () {
-          return 'input_' + ( Math.random().toString(36).substring(2) );
-        }
       }
 
     },

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -398,7 +398,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.$ = {}
       }
       if (!this.$.input) {
-        this.$.input = this.$$('#'+this._inputId);
+        this._generateInputId();
+        this.$.input = this.$$('#' + this._inputId);
       }
       return this.$.input;
     },
@@ -418,7 +419,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
-      this._updateInputId();
       this._updateAriaLabelledBy();
 
       if (this.inputElement &&
@@ -532,8 +532,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._ariaLabelledBy = labelledBy;
     },
 
-    _updateInputId: function() {
-      this._inputId =  'input-' + Polymer.PaperInputHelper.NextInputID++;
+    _generateInputId: function() {
+      if (!this._inputId || this._inputId === '') {
+        this._inputId =  'input-' + Polymer.PaperInputHelper.NextInputID++;
+      }
     },
 
     _onChange:function(event) {

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -463,7 +463,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       Polymer.IronControlState._focusBlurHandler.call(this, event);
 
       // Forward the focus to the nested input.
-      if (this.focused && !this._shiftTabPressed)
+      if (this.focused && !this._shiftTabPressed && this._focusableElement)
         this._focusableElement.focus();
     },
 

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -368,6 +368,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _ariaLabelledBy: {
         type: String,
         value: ''
+      },
+
+      _inputId: {
+        type: String,
+        value: ''
       }
 
     },
@@ -388,7 +393,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Returns a reference to the input element.
      */
     get inputElement() {
-      return this.$.input;
+      return this.querySelector('input');
     },
 
     /**
@@ -407,6 +412,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     attached: function() {
       this._updateAriaLabelledBy();
+      this._updateInputId();
 
       if (this.inputElement &&
           this._typesThatHaveText.indexOf(this.inputElement.type) !== -1) {
@@ -517,6 +523,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         label.id = labelledBy;
       }
       this._ariaLabelledBy = labelledBy;
+    },
+
+    _updateInputId: function () {
+      this._inputId = 'input_' + Polymer.PaperInputHelper.NextLabelID;
     },
 
     _onChange:function(event) {

--- a/paper-input.html
+++ b/paper-input.html
@@ -82,13 +82,13 @@ style this element.
         display: none !important;
       }
 
-      input::-webkit-outer-spin-button,                                                                                                     
-      input::-webkit-inner-spin-button {                                                                                                    
-        @apply(--paper-input-container-input-webkit-spinner);                                                                                                                                                                                      
+      input::-webkit-outer-spin-button,
+      input::-webkit-inner-spin-button {
+        @apply(--paper-input-container-input-webkit-spinner);
       }
-      
+
       input::-webkit-clear-button {
-        @apply(--paper-input-container-input-webkit-clear);  
+        @apply(--paper-input-container-input-webkit-clear);
       }
 
       input::-webkit-input-placeholder {
@@ -120,9 +120,9 @@ style this element.
 
       <content select="[prefix]"></content>
 
-      <label hidden$="[[!label]]" aria-hidden="true" for="input">[[label]]</label>
+      <label hidden$="[[!label]]" aria-hidden="true" for="[[_inputId]]">[[label]]</label>
 
-      <input is="iron-input" id="input"
+      <input is="iron-input" id="[[_inputId]]"
         aria-labelledby$="[[_ariaLabelledBy]]"
         aria-describedby$="[[_ariaDescribedBy]]"
         disabled$="[[disabled]]"

--- a/paper-input.html
+++ b/paper-input.html
@@ -122,7 +122,7 @@ style this element.
 
       <label hidden$="[[!label]]" aria-hidden="true" for="[[_inputId]]">[[label]]</label>
 
-      <input is="iron-input" id="[[_inputId]]"
+      <input is="iron-input" id$="[[_inputId]]"
         aria-labelledby$="[[_ariaLabelledBy]]"
         aria-describedby$="[[_ariaDescribedBy]]"
         disabled$="[[disabled]]"

--- a/paper-input.html
+++ b/paper-input.html
@@ -120,9 +120,10 @@ style this element.
 
       <content select="[prefix]"></content>
 
-      <label hidden$="[[!label]]" aria-hidden="true">[[label]]</label>
+      <label hidden$="[[!label]]" aria-hidden="true" for$="[[_inputId]]">[[label]]</label>
 
       <input is="iron-input"
+        id$="[[_inputId]]"
         class="input-element"
         aria-labelledby$="[[_ariaLabelledBy]]"
         aria-describedby$="[[_ariaDescribedBy]]"

--- a/paper-input.html
+++ b/paper-input.html
@@ -120,9 +120,9 @@ style this element.
 
       <content select="[prefix]"></content>
 
-      <label hidden$="[[!label]]" aria-hidden="true" for="[[_inputId]]">[[label]]</label>
+      <label hidden$="[[!label]]" aria-hidden="true">[[label]]</label>
 
-      <input is="iron-input" id$="[[_inputId]]"
+      <input is="iron-input"
         class="input-element"
         aria-labelledby$="[[_ariaLabelledBy]]"
         aria-describedby$="[[_ariaDescribedBy]]"

--- a/paper-input.html
+++ b/paper-input.html
@@ -123,6 +123,7 @@ style this element.
       <label hidden$="[[!label]]" aria-hidden="true" for="[[_inputId]]">[[label]]</label>
 
       <input is="iron-input" id$="[[_inputId]]"
+        class="input-element"
         aria-labelledby$="[[_ariaLabelledBy]]"
         aria-describedby$="[[_ariaDescribedBy]]"
         disabled$="[[disabled]]"

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -132,29 +132,15 @@ style this element.
     },
 
     _ariaLabelledByChanged: function(ariaLabelledBy) {
-      if (this.textareaElement) {
-        this.textareaElement.setAttribute('aria-labelledby', ariaLabelledBy);
-      }
+      this._focusableElement.setAttribute('aria-labelledby', ariaLabelledBy);
     },
 
     _ariaDescribedByChanged: function(ariaDescribedBy) {
-      if (this.textareaElement) {
-        this.textareaElement.setAttribute('aria-describedby', ariaDescribedBy);
-      }
+      this._focusableElement.setAttribute('aria-describedby', ariaDescribedBy);
     },
 
     get _focusableElement() {
-      return this.textareaElement;
-    },
-
-    get textareaElement() {
-      if (!this.$) {
-        this.$ = {}
-      }
-      if (!this.$.textarea) {
-        this.$.textarea = this.querySelector('textarea');
-      }
-      return this.$.textarea;
+      return this.inputElement.textarea;
     }
   });
 </script>

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -51,9 +51,10 @@ style this element.
 
     <paper-input-container no-label-float$="[[noLabelFloat]]" always-float-label="[[_computeAlwaysFloatLabel(alwaysFloatLabel,placeholder)]]" auto-validate$="[[autoValidate]]" disabled$="[[disabled]]" invalid="[[invalid]]">
 
-      <label hidden$="[[!label]]" aria-hidden="true">[[label]]</label>
+      <label hidden$="[[!label]]" aria-hidden="true" for$="[[_inputId]]">[[label]]</label>
 
       <iron-autogrow-textarea class="input-element paper-input-input"
+        id$="[[_inputId]]"
         bind-value="{{value}}"
         invalid="{{invalid}}"
         validator$="[[validator]]"

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -53,7 +53,8 @@ style this element.
 
       <label hidden$="[[!label]]" aria-hidden="true">[[label]]</label>
 
-      <iron-autogrow-textarea id="input" class="paper-input-input"
+      <iron-autogrow-textarea  id$="[[_inputId]]"
+        class="input-element paper-input-input"
         bind-value="{{value}}"
         invalid="{{invalid}}"
         validator$="[[validator]]"
@@ -131,15 +132,19 @@ style this element.
     },
 
     _ariaLabelledByChanged: function(ariaLabelledBy) {
-      this.$.input.textarea.setAttribute('aria-labelledby', ariaLabelledBy);
+      this.textareaElement.setAttribute('aria-labelledby', ariaLabelledBy);
     },
 
     _ariaDescribedByChanged: function(ariaDescribedBy) {
-      this.$.input.textarea.setAttribute('aria-describedby', ariaDescribedBy);
+      this.textareaElement.setAttribute('aria-describedby', ariaDescribedBy);
     },
 
     get _focusableElement() {
-      return this.$.input.textarea;
+      return this.textareaElement;
     },
+
+    get textareaElement() {
+      return this.inputElement.textarea;
+    }
   });
 </script>

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -53,8 +53,7 @@ style this element.
 
       <label hidden$="[[!label]]" aria-hidden="true">[[label]]</label>
 
-      <iron-autogrow-textarea  id$="[[_inputId]]"
-        class="input-element paper-input-input"
+      <iron-autogrow-textarea class="input-element paper-input-input"
         bind-value="{{value}}"
         invalid="{{invalid}}"
         validator$="[[validator]]"

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -144,7 +144,7 @@ style this element.
     },
 
     get textareaElement() {
-      return this.inputElement.textarea;
+      return this.querySelector('textarea');
     }
   });
 </script>

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -132,11 +132,15 @@ style this element.
     },
 
     _ariaLabelledByChanged: function(ariaLabelledBy) {
-      this.textareaElement.setAttribute('aria-labelledby', ariaLabelledBy);
+      if (this.textareaElement) {
+        this.textareaElement.setAttribute('aria-labelledby', ariaLabelledBy);
+      }
     },
 
     _ariaDescribedByChanged: function(ariaDescribedBy) {
-      this.textareaElement.setAttribute('aria-describedby', ariaDescribedBy);
+      if (this.textareaElement) {
+        this.textareaElement.setAttribute('aria-describedby', ariaDescribedBy);
+      }
     },
 
     get _focusableElement() {
@@ -144,7 +148,13 @@ style this element.
     },
 
     get textareaElement() {
-      return this.querySelector('textarea');
+      if (!this.$) {
+        this.$ = {}
+      }
+      if (!this.$.textarea) {
+        this.$.textarea = this.querySelector('textarea');
+      }
+      return this.$.textarea;
     }
   });
 </script>


### PR DESCRIPTION
The 2.x PR is here: https://github.com/PolymerElements/paper-input/pull/609

Fixes #600: Chrome has recently started throwing some auditing errors in the console if any `<input type="password">` has the same `id` as any other `input`. This means that in Shady DOM, if you have two `paper-inputs` on a page, you'd get this error. This fixes that by generating unique IDs for the inputs in the page.

(this is PR https://github.com/PolymerElements/paper-input/pull/602 with like one extra commit on it, thanks @ipuiu for doing all the work!)