### PR TITLE
2.x: Generate unique IDs for the input in the shadow root

### DIFF
--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -19,6 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.PaperInputHelper = {};
   Polymer.PaperInputHelper.NextLabelID = 1;
   Polymer.PaperInputHelper.NextAddonID = 1;
+  Polymer.PaperInputHelper.NextInputID = 1;
 
   /**
    * Use `Polymer.PaperInputBehavior` to implement inputs with `<paper-input-container>`. This
@@ -361,8 +362,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _ariaLabelledBy: {
         type: String,
         value: ''
-      }
+      },
 
+      _inputId: {
+        type: String,
+        value: ''
+      }
     },
 
     listeners: {
@@ -381,6 +386,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Returns a reference to the input element.
      */
     get inputElement() {
+      // Chrome generates audit errors if an <input type="password"> has a
+      // duplicate ID, which is almost always true in Shady DOM. Generate
+      // a unique ID instead.
+      if (!this.$) {
+        this.$ = {}
+      }
+      if (!this.$.input) {
+        this._generateInputId();
+        this.$.input = this.$$('#' + this._inputId);
+      }
       return this.$.input;
     },
 
@@ -514,6 +529,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         label.id = labelledBy;
       }
       this._ariaLabelledBy = labelledBy;
+    },
+
+    _generateInputId: function() {
+      if (!this._inputId || this._inputId === '') {
+        this._inputId =  'input-' + Polymer.PaperInputHelper.NextInputID++;
+      }
     },
 
     _onChange:function(event) {

--- a/paper-input.html
+++ b/paper-input.html
@@ -230,7 +230,7 @@ Custom property | Description | Default
         allowed-pattern="[[allowedPattern]]"
         invalid="{{invalid}}"
         validator="[[validator]]">
-      <input id="nativeInput"
+      <input
         aria-labelledby$="[[_ariaLabelledBy]]"
         aria-describedby$="[[_ariaDescribedBy]]"
         disabled$="[[disabled]]"
@@ -307,7 +307,7 @@ Custom property | Description | Default
 
     _onIronInputReady: function() {
       if (this.inputElement &&
-          this._typesThatHaveText.indexOf(this.$.nativeInput.type) !== -1) {
+          this._typesThatHaveText.indexOf(this.$$('input').type) !== -1) {
         this.alwaysFloatLabel = true;
       }
 

--- a/paper-input.html
+++ b/paper-input.html
@@ -306,8 +306,13 @@ Custom property | Description | Default
     },
 
     _onIronInputReady: function() {
+      // Even though this is only used in the next line, save this for
+      // backwards compatibility, since the native input had this ID until 2.0.5.
+      if (!this.$.nativeInput) {
+        this.$.nativeInput = this.$$('input');
+      }
       if (this.inputElement &&
-          this._typesThatHaveText.indexOf(this.$$('input').type) !== -1) {
+          this._typesThatHaveText.indexOf(this.$.nativeInput.type) !== -1) {
         this.alwaysFloatLabel = true;
       }
 

--- a/paper-input.html
+++ b/paper-input.html
@@ -161,7 +161,7 @@ Custom property | Description | Default
 
       <slot name="prefix" slot="prefix"></slot>
 
-      <label hidden$="[[!label]]" aria-hidden="true" for="input" slot="label">[[label]]</label>
+      <label hidden$="[[!label]]" aria-hidden="true" for$="[[_inputId]]" slot="label">[[label]]</label>
 
       <span id="template-placeholder"></span>
 
@@ -183,7 +183,9 @@ Custom property | Description | Default
     Expect some conditional code (especially in the tests).
    -->
   <template id="v0">
-    <input is="iron-input" id="input" slot="input"
+    <input is="iron-input" slot="input"
+        class="input-element"
+        id$="[[_inputId]]"
         aria-labelledby$="[[_ariaLabelledBy]]"
         aria-describedby$="[[_ariaDescribedBy]]"
         disabled$="[[disabled]]"
@@ -221,7 +223,9 @@ Custom property | Description | Default
 
   <template id="v1">
     <!-- Need to bind maxlength so that the paper-input-char-counter works correctly -->
-    <iron-input bind-value="{{value}}" id="input" slot="input"
+    <iron-input bind-value="{{value}}" slot="input"
+        class="input-element"
+        id$="[[_inputId]]"
         maxlength$="[[maxlength]]"
         allowed-pattern="[[allowedPattern]]"
         invalid="{{invalid}}"

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -55,9 +55,10 @@ style this element.
         disabled$="[[disabled]]"
         invalid="[[invalid]]">
 
-      <label hidden$="[[!label]]" aria-hidden="true" for="input" slot="label">[[label]]</label>
+      <label hidden$="[[!label]]" aria-hidden="true" for$="[[_inputId]]" slot="label">[[label]]</label>
 
-      <iron-autogrow-textarea id="input" class="paper-input-input" slot="input"
+      <iron-autogrow-textarea class="paper-input-input" slot="input"
+        id$="[[_inputId]]"
         aria-labelledby$="[[_ariaLabelledBy]]"
         aria-describedby$="[[_ariaDescribedBy]]"
         bind-value="{{value}}"
@@ -151,15 +152,15 @@ style this element.
     },
 
     _ariaLabelledByChanged: function(ariaLabelledBy) {
-      this.$.input.textarea.setAttribute('aria-labelledby', ariaLabelledBy);
+      this._focusableElement.setAttribute('aria-labelledby', ariaLabelledBy);
     },
 
     _ariaDescribedByChanged: function(ariaDescribedBy) {
-      this.$.input.textarea.setAttribute('aria-describedby', ariaDescribedBy);
+      this._focusableElement.setAttribute('aria-describedby', ariaDescribedBy);
     },
 
     get _focusableElement() {
-      return this.$.input.textarea;
+      return this.inputElement.textarea;
     },
   });
 </script>


### PR DESCRIPTION
The 1.x PR is here: https://github.com/PolymerElements/paper-input/pull/608

Fixes #600: Chrome has recently started throwing some auditing errors in the console if any `<input type="password">` has the same `id` as any other `input`. This means that in Shady DOM, if you have two `paper-inputs` on a page, you'd get this error. This fixes that by generating unique IDs for the inputs in the page.