### PR TITLE
styles not applied to slotted input in 2.x

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -171,6 +171,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             .custom-parent {
               font-size: 12px;
             }
+            paper-input.custom:hover {
+              border: 1px solid #29B6F6;
+            }
             paper-input.custom {
               margin-bottom: 14px;
               --paper-input-container-color: black;

--- a/demo/index.html
+++ b/demo/index.html
@@ -162,6 +162,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </paper-input-container>
       </template>
     </demo-snippet>
+
+    <h3>Inputs can be completely restyled</h3>
+    <demo-snippet>
+      <template>
+        <custom-style>
+          <style is="custom-style">
+            .custom-parent {
+              font-size: 12px;
+            }
+            paper-input.custom {
+              margin-bottom: 14px;
+              --paper-input-container-color: black;
+              --paper-input-container-focus-color: black;
+              --paper-input-container-invalid-color: black;
+              border: 1px solid #BDBDBD;
+              border-radius: 5px;
+
+              /* Reset some defaults */
+              --paper-input-container: { padding: 0;};
+              --paper-input-container-underline: { display: none; height: 0;};
+              --paper-input-container-underline-focus: { display: none; };
+
+              /* New custom styles */
+              --paper-input-container-input: {
+                box-sizing: border-box;
+                font-size: inherit;
+                padding: 4px;
+              };
+              --paper-input-container-input-focus: {
+                background: rgba(0, 0, 0, 0.1);
+              };
+              --paper-input-container-input-invalid: {
+                background: rgba(255, 0, 0, 0.3);
+              };
+              --paper-input-container-label: {
+                top: -8px;
+                left: 4px;
+                background: white;
+                padding: 2px;
+                font-weight: bold;
+              };
+              --paper-input-container-label-floating: {
+                width: auto;
+              };
+            }
+          </style>
+        </custom-style>
+        <div class="custom-parent">
+          <paper-input class="custom" label="Name" value="Batman" always-float-label>
+          </paper-input>
+          <paper-input class="custom" label="Address (letters only, will autovalidate)"
+              always-float-label auto-validate pattern="[a-zA-Z]*">
+          </paper-input>
+        </div>
+      </template>
+    </demo-snippet>
   </div>
 
   <script>

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -288,7 +288,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-content.label-is-hidden ::slotted(.paper-input-label) {
         visibility: hidden;
       }
-      
+
       .input-content ::slotted(input),
       .input-content ::slotted(iron-input),
       .input-content ::slotted(textarea),

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -288,12 +288,9 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-content.label-is-hidden ::slotted(.paper-input-label) {
         visibility: hidden;
       }
-
-      .input-content ::slotted(iron-input) {
-        @apply --paper-input-container-shared-input-style;
-      }
-
+      
       .input-content ::slotted(input),
+      .input-content ::slotted(iron-input),
       .input-content ::slotted(textarea),
       .input-content ::slotted(iron-autogrow-textarea),
       .input-content ::slotted(.paper-input-input) {
@@ -307,6 +304,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       }
 
       .input-content.focused ::slotted(input),
+      .input-content.focused ::slotted(iron-input),
       .input-content.focused ::slotted(textarea),
       .input-content.focused ::slotted(iron-autogrow-textarea),
       .input-content.focused ::slotted(.paper-input-input) {
@@ -314,6 +312,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       }
 
       .input-content.is-invalid ::slotted(input),
+      .input-content.is-invalid ::slotted(iron-input),
       .input-content.is-invalid ::slotted(textarea),
       .input-content.is-invalid ::slotted(iron-autogrow-textarea),
       .input-content.is-invalid ::slotted(.paper-input-input) {

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -124,6 +124,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
         outline: none;
         box-shadow: none;
         padding: 0;
+        margin: 0;
         width: 100%;
         max-width: 100%;
         background: transparent;

--- a/paper-input.html
+++ b/paper-input.html
@@ -91,13 +91,21 @@ Custom property | Description | Default
       input {
         /* Firefox sets a min-width on the input, which can cause layout issues */
         min-width: 0;
-        @apply --paper-input-container-shared-input-style;
-        @apply --paper-input-container-input;
       }
 
-      input::-webkit-outer-spin-button,
-      input::-webkit-inner-spin-button {
-        @apply --paper-input-container-input-webkit-spinner;
+      /* In 1.x, the <input> is distributed to paper-input-container, which styles it.
+      In 2.x the <iron-input> is distributed to paper-input-container, which styles
+      it, but in order for this to work correctly, we need to reset some
+      of the native input's properties to inherit (from the iron-input) */
+      iron-input input {
+        @apply --paper-input-container-shared-input-style;
+        font-family: inherit;
+        font-weight: inherit;
+        font-size: inherit;
+        letter-spacing: inherit;
+        word-spacing: inherit;
+        line-height: inherit;
+        text-shadow: inherit;
       }
 
       input:disabled {

--- a/paper-input.html
+++ b/paper-input.html
@@ -97,7 +97,7 @@ Custom property | Description | Default
       In 2.x the <iron-input> is distributed to paper-input-container, which styles
       it, but in order for this to work correctly, we need to reset some
       of the native input's properties to inherit (from the iron-input) */
-      iron-input input {
+      iron-input > input {
         @apply --paper-input-container-shared-input-style;
         font-family: inherit;
         font-weight: inherit;

--- a/paper-input.html
+++ b/paper-input.html
@@ -89,25 +89,15 @@ Custom property | Description | Default
       }
 
       input {
-        position: relative; /* to make a stacking context */
-        outline: none;
-        box-shadow: none;
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        max-width: 100%;
-        background: transparent;
-        border: none;
-        color: var(--paper-input-container-input-color, var(--primary-text-color));
-        -webkit-appearance: none;
-        text-align: inherit;
-        vertical-align: bottom;
-
         /* Firefox sets a min-width on the input, which can cause layout issues */
         min-width: 0;
-
-        @apply --paper-font-subhead;
+        @apply --paper-input-container-shared-input-style;
         @apply --paper-input-container-input;
+      }
+
+      input::-webkit-outer-spin-button,
+      input::-webkit-inner-spin-button {
+        @apply --paper-input-container-input-webkit-spinner;
       }
 
       input:disabled {


### PR DESCRIPTION
Fixes #638, #636, #613.

It's hard to add a test for this, so I've added a super complex `demo-snippet`:
![screen shot 2018-03-28 at 12 32 20 pm](https://user-images.githubusercontent.com/1369170/38052026-ceebeb18-3284-11e8-95ff-8fa8559b8955.png)
