### PR TITLE
fix color not inheriting

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -176,6 +176,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
             paper-input.custom {
               margin-bottom: 14px;
+              --primary-text-color: #01579B;
               --paper-input-container-color: black;
               --paper-input-container-focus-color: black;
               --paper-input-container-invalid-color: black;
@@ -192,7 +193,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 box-sizing: border-box;
                 font-size: inherit;
                 padding: 4px;
-                color: #29B6F6;
               };
               --paper-input-container-input-focus: {
                 background: rgba(0, 0, 0, 0.1);

--- a/demo/index.html
+++ b/demo/index.html
@@ -192,6 +192,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 box-sizing: border-box;
                 font-size: inherit;
                 padding: 4px;
+                color: #29B6F6;
               };
               --paper-input-container-input-focus: {
                 background: rgba(0, 0, 0, 0.1);

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -296,6 +296,9 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-content ::slotted(iron-autogrow-textarea),
       .input-content ::slotted(.paper-input-input) {
         @apply --paper-input-container-shared-input-style;
+        /* The apply shim doesn't apply the nested color custom property,
+          so we have to re-apply it here. */
+        color: var(--paper-input-container-input-color, var(--primary-text-color));
         @apply --paper-input-container-input;
       }
 

--- a/paper-input.html
+++ b/paper-input.html
@@ -99,16 +99,14 @@ Custom property | Description | Default
       of the native input's properties to inherit (from the iron-input) */
       iron-input > input {
         @apply --paper-input-container-shared-input-style;
-        /* The apply shim doesn't apply the nested color custom property,
-          so we have to re-apply it here. */
-        color: var(--paper-input-container-input-color, var(--primary-text-color));
         font-family: inherit;
         font-weight: inherit;
         font-size: inherit;
         letter-spacing: inherit;
         word-spacing: inherit;
         line-height: inherit;
-        text-shadow: inherit;    
+        text-shadow: inherit;
+        color: inherit;
       }
 
       input:disabled {

--- a/paper-input.html
+++ b/paper-input.html
@@ -106,6 +106,7 @@ Custom property | Description | Default
         word-spacing: inherit;
         line-height: inherit;
         text-shadow: inherit;
+        color: inherit;
       }
 
       input:disabled {

--- a/paper-input.html
+++ b/paper-input.html
@@ -99,14 +99,16 @@ Custom property | Description | Default
       of the native input's properties to inherit (from the iron-input) */
       iron-input > input {
         @apply --paper-input-container-shared-input-style;
+        /* The apply shim doesn't apply the nested color custom property,
+          so we have to re-apply it here. */
+        color: var(--paper-input-container-input-color, var(--primary-text-color));
         font-family: inherit;
         font-weight: inherit;
         font-size: inherit;
         letter-spacing: inherit;
         word-spacing: inherit;
         line-height: inherit;
-        text-shadow: inherit;
-        color: inherit;
+        text-shadow: inherit;    
       }
 
       input:disabled {


### PR DESCRIPTION
#639 changed how the `iron-input > input` inherits styles, but didn't inherit `color` correctly. @sorvell  says there's a shim limitations where you can't have custom properties inside of an `@apply`, so that's why the custom property inside of the `paper-input-container-shared-input-style` mixin doesn't actually get applied