### PR TITLE
Fix TypeScript compilation of paper-input

### DIFF
--- a/paper-input.d.ts
+++ b/paper-input.d.ts
@@ -67,6 +67,7 @@
  * `--paper-input-container-ms-clear` | Mixin applied to the Internet Explorer reveal button (the eyeball) | {}
  */
 interface PaperInputElement extends Polymer.Element, Polymer.PaperInputBehavior, Polymer.IronFormElementBehavior {
+  value: string|null|undefined;
 
   /**
    * Returns a reference to the focusable element. Overridden from PaperInputBehavior

--- a/paper-input.html
+++ b/paper-input.html
@@ -276,6 +276,13 @@ Custom property | Description | Default
       Polymer.IronFormElementBehavior
     ],
 
+    properties: {
+      value: {
+        // Required for the correct TypeScript type-generation
+        type: String
+      }
+    },
+
     beforeRegister: function() {
       // We need to tell which kind of of template to stamp based on
       // what kind of `iron-input` we got, but because of polyfills and


### PR DESCRIPTION
As a result of a TypeScript update in `IronFormElementBehavior` (https://github.com/PolymerElements/iron-form-element-behavior/pull/41) to address an issue in `paper-slider` (https://github.com/Polymer/gen-typescript-declarations/issues/103) this inadvertently broke the compilation of `paper-input`. The fix is the same as for `paper-slider`, declare `value` again with the correct type in the concrete subclass.

Fixes #645 