### PR TITLE
Automatic format!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_script:
     npm run update-types && git diff --exit-code || (echo -e
     '\n\033[31mERROR:\033[0m Typings are stale. Please run "npm run
     update-types".' && false)
+  - >-
+    npm run format && git diff --exit-code || (echo -e '\n\033[31mERROR:\033[0m
+    Project is not formatted. Please run "npm run format".' && false)
 env:
   global:
     - secure: >-

--- a/demo/ssn-input.html
+++ b/demo/ssn-input.html
@@ -77,40 +77,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer({
       is: 'ssn-input',
 
-      behaviors: [
-        Polymer.IronValidatableBehavior
-      ],
+      behaviors: [Polymer.IronValidatableBehavior],
 
       properties: {
-        value: {
-          notify: true,
-          type: String
-        },
+        value: {notify: true, type: String},
 
-        _ssn1: {
-          type: String,
-          value: ''
-        },
+        _ssn1: {type: String, value: ''},
 
-        _ssn2: {
-          type: String,
-          value: ''
-        },
+        _ssn2: {type: String, value: ''},
 
-        _ssn3: {
-          type: String,
-          value: ''
-        },
+        _ssn3: {type: String, value: ''},
 
-        validator: {
-          type: String,
-          value: 'ssn-validator'
-        }
+        validator: {type: String, value: 'ssn-validator'}
       },
 
-      observers: [
-        '_computeValue(_ssn1,_ssn2,_ssn3)'
-      ],
+      observers: ['_computeValue(_ssn1,_ssn2,_ssn3)'],
 
       _computeValue: function(ssn1, ssn2, ssn3) {
         this.value = ssn1.trim() + '-' + ssn2.trim() + '-' + ssn3.trim();
@@ -119,9 +100,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       beforeRegister: function() {
         var template = Polymer.DomModule.import('ssn-input', 'template');
         var version = Polymer.Element ? 'v1' : 'v0';
-        var inputTemplate = Polymer.DomModule.import('ssn-input', 'template#' + version);
-        var inputPlaceholder = template.content.querySelector('#template-placeholder');
-        inputPlaceholder.parentNode.replaceChild(inputTemplate.content, inputPlaceholder);
+        var inputTemplate =
+            Polymer.DomModule.import('ssn-input', 'template#' + version);
+        var inputPlaceholder =
+            template.content.querySelector('#template-placeholder');
+        inputPlaceholder.parentNode.replaceChild(
+            inputTemplate.content, inputPlaceholder);
       },
     });
   </script>

--- a/demo/ssn-validator.html
+++ b/demo/ssn-validator.html
@@ -15,9 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer({
     is: 'ssn-validator',
 
-    behaviors: [
-      Polymer.IronValidatorBehavior
-    ],
+    behaviors: [Polymer.IronValidatorBehavior],
 
     validate: function(value) {
       // this regex validates incomplete ssn's (by design)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,23 +3,34 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
+      }
+    },
     "@polymer/gen-typescript-declarations": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.0.tgz",
-      "integrity": "sha512-a5DFXI3TdZSVOMH4608LVaBLmcr+mwM2+B8OSBiB9WFNCtdqzUXwtB5We6vBzrThXlO4uRo7d2pEqjNXMAlEkA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.2.tgz",
+      "integrity": "sha512-9P946+nIkSm+761v3oxH/QVgJozhsInldKY3h8AVstdXkA8W0Fij84pqsFv1nrRuPGj4Pv71crzoZpFnLkNmKQ==",
       "dev": true,
       "requires": {
         "@types/doctrine": "0.0.3",
         "@types/fs-extra": "5.0.1",
         "@types/glob": "5.0.35",
         "command-line-args": "5.0.2",
-        "command-line-usage": "4.1.0",
+        "command-line-usage": "5.0.4",
         "doctrine": "2.1.0",
         "escodegen": "1.9.1",
         "fs-extra": "5.0.0",
         "glob": "7.1.2",
         "minimatch": "3.0.4",
-        "polymer-analyzer": "3.0.0-pre.12"
+        "polymer-analyzer": "3.0.0-pre.14",
+        "vscode-uri": "1.0.3"
       }
     },
     "@types/babel-generator": {
@@ -106,7 +117,7 @@
       "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.4"
       }
     },
     "@types/glob": {
@@ -117,8 +128,14 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.4"
       }
+    },
+    "@types/is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -127,9 +144,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.4.tgz",
+      "integrity": "sha512-Awg4BcUYiZtNKoveGOu654JVPt11V/KIC77iBz8NweyoOAZpz5rUJfPDwwD+ajfTs2HndbTCEB8IuLfX9m/mmw==",
       "dev": true
     },
     "@types/parse5": {
@@ -138,25 +155,25 @@
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.4"
+      }
+    },
+    "@types/resolve": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+      "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.6.4"
       }
     },
     "@types/winston": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.8.tgz",
-      "integrity": "sha512-QqR0j08RCS1AQYPMRPHikEpcmK+2aEEbcSzWLwOqyJ4FhLmHUx/WjRrnn7tTQg/y4IKnMhzskh/o7qvGIZZ7iA==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.9.tgz",
+      "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
-      }
-    },
-    "ansi-escape-sequences": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0"
+        "@types/node": "9.6.4"
       }
     },
     "ansi-regex": {
@@ -166,10 +183,13 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.1"
+      }
     },
     "argv-tools": {
       "version": "0.1.1",
@@ -181,6 +201,24 @@
         "find-replace": "2.0.1"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-back": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
@@ -190,19 +228,37 @@
         "typical": "2.6.1"
       }
     },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "async": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
       "dev": true
     },
+    "atob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+      "dev": true
+    },
     "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
+      "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "2.3.2",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
       }
@@ -223,12 +279,45 @@
         "trim-right": "1.0.1"
       },
       "dependencies": {
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.5",
+            "to-fast-properties": "1.0.3"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
+      "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "7.0.0-beta.3",
+        "babel-template": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
+      "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
+      "dev": true,
+      "requires": {
+        "babel-types": "7.0.0-beta.3"
       }
     },
     "babel-messages": {
@@ -246,43 +335,78 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.5",
         "regenerator-runtime": "0.11.1"
       }
     },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+    "babel-template": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
+      "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.3",
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
         "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
+      "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-helper-function-name": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
+        "debug": "3.1.0",
+        "globals": "10.4.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
       }
     },
     "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+      "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
         "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
       }
     },
     "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
       "dev": true
     },
     "balanced-match": {
@@ -291,10 +415,65 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "bower": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
-      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz",
+      "integrity": "sha1-54dqB23rgTf30GUl3F6MZtuC8oo=",
       "dev": true
     },
     "brace-expansion": {
@@ -307,23 +486,157 @@
         "concat-map": "0.0.1"
       }
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "cancel-token": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+      "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
+      "dev": true,
+      "requires": {
+        "@types/node": "4.2.23"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "4.2.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
+          "integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w==",
+          "dev": true
+        }
+      }
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "5.3.0"
+      }
+    },
+    "clang-format": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.3.tgz",
+      "integrity": "sha512-x90Hac4ERacGDcZSvHKK58Ga0STuMD+Doi5g0iG2zf7wlJef5Huvhs/3BvMRFxwRYyYSdl6mpQNrtfMxE8MQzw==",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "glob": "7.1.2",
+        "resolve": "1.7.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
       }
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -346,16 +659,22 @@
       }
     },
     "command-line-usage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-h17lBwC5bl5RdukPbXji75+cg2/Qbny6kGsmLoy34s9DNH90RwRvJKb+VU5j4YY9HzYl7twLaOWDJQ4b9U+p/Q==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "4.0.0",
         "array-back": "2.0.0",
-        "table-layout": "0.4.2",
+        "chalk": "2.3.2",
+        "table-layout": "0.4.3",
         "typical": "2.6.1"
       }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -363,10 +682,16 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
       "dev": true
     },
     "cssbeautify": {
@@ -382,13 +707,19 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.5.0",
@@ -401,6 +732,47 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -427,7 +799,7 @@
       "dev": true,
       "requires": {
         "@types/parse5": "2.2.34",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "parse5": "4.0.0"
       }
     },
@@ -468,17 +840,183 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
+    "fast-glob": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.0.tgz",
+      "integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.1",
+        "micromatch": "3.1.10"
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
     },
     "find-replace": {
       "version": "2.0.1",
@@ -488,6 +1026,21 @@
       "requires": {
         "array-back": "2.0.0",
         "test-value": "3.0.0"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
       }
     },
     "fs-extra": {
@@ -507,6 +1060,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -521,10 +1080,37 @@
         "path-is-absolute": "1.0.1"
       }
     },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+      "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
       "dev": true
     },
     "graceful-fs": {
@@ -540,6 +1126,44 @@
       "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "indent": {
@@ -565,13 +1189,90 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-      "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -581,6 +1282,79 @@
       "requires": {
         "number-is-nan": "1.0.1"
       }
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-odd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -610,9 +1384,15 @@
       }
     },
     "jsonschema": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
     "levn": {
@@ -643,6 +1423,12 @@
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -650,6 +1436,48 @@
       "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "merge2": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
+      "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.9",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "minimatch": {
@@ -670,17 +1498,107 @@
         "minimatch": "3.0.4"
       }
     },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nanomatch": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -711,10 +1629,34 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "plylog": {
@@ -724,8 +1666,8 @@
       "dev": true,
       "requires": {
         "@types/node": "4.2.23",
-        "@types/winston": "2.3.8",
-        "winston": "2.4.0"
+        "@types/winston": "2.3.9",
+        "winston": "2.4.1"
       },
       "dependencies": {
         "@types/node": {
@@ -737,9 +1679,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "3.0.0-pre.12",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.12.tgz",
-      "integrity": "sha512-QQL70IC85hI6q9uQeresEMcT1Qf8YR/zDe1qG8WWeeFAZk8z0lmzUpsfcAWz+bM4wpDdXrtd4HitIs4p0CHl/w==",
+      "version": "3.0.0-pre.14",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.14.tgz",
+      "integrity": "sha512-1Zh/smUWMrjBB7NFUk8i7EAnjO81PqhI0/RzMMy9VgAbPQ6jOROwFX71T02CgpkZYa0O66Ybl7G3+4+0S1aF1Q==",
       "dev": true,
       "requires": {
         "@types/babel-generator": "6.25.1",
@@ -751,27 +1693,34 @@
         "@types/clone": "0.1.30",
         "@types/cssbeautify": "0.3.1",
         "@types/doctrine": "0.0.1",
+        "@types/is-windows": "0.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "6.0.101",
+        "@types/node": "6.0.105",
         "@types/parse5": "2.2.34",
+        "@types/resolve": "0.0.6",
         "babel-generator": "6.26.1",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.44",
+        "cancel-token": "0.1.1",
         "chalk": "1.1.3",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "cssbeautify": "0.3.1",
         "doctrine": "2.1.0",
         "dom5": "3.0.0",
         "indent": "0.0.2",
-        "jsonschema": "1.2.2",
+        "is-windows": "1.0.2",
+        "jsonschema": "1.2.4",
         "minimatch": "3.0.4",
         "parse5": "4.0.0",
-        "polymer-project-config": "3.9.0",
+        "path-is-inside": "1.0.2",
+        "polymer-project-config": "3.13.0",
+        "resolve": "1.7.0",
         "shady-css-parser": "0.1.0",
         "stable": "0.1.6",
         "strip-indent": "2.0.0",
-        "vscode-uri": "1.0.1"
+        "vscode-uri": "1.0.3",
+        "whatwg-url": "6.4.0"
       },
       "dependencies": {
         "@types/doctrine": {
@@ -781,37 +1730,74 @@
           "dev": true
         },
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "polymer-project-config": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.9.0.tgz",
-      "integrity": "sha512-WPOqlV2W/M4Ni40QIqYSv8PE7H4rjiPm1KEf02QPtjZOGlAC4Rv7e6UJ1Ke1O70WT5bydcsEn3LViFIqYpVOJw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.13.0.tgz",
+      "integrity": "sha512-0E1iSOpo2xFMvMomSDFl48J8IOUWmM+sfHGJSQSVfIu8GXDgz2TVraad+rEMZDbj8uxiRFvQZyouHhikxhVFpQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.101",
-        "jsonschema": "1.2.2",
+        "@types/node": "6.0.105",
+        "jsonschema": "1.2.4",
         "minimatch-all": "1.1.0",
         "plylog": "0.5.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
           "dev": true
         }
       }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
       "dev": true
     },
     "reduce-flatten": {
@@ -826,6 +1812,28 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -835,11 +1843,186 @@
         "is-finite": "1.0.2"
       }
     },
+    "resolve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
+      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
     "shady-css-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
       "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA==",
       "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -847,6 +2030,34 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "optional": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "dev": true,
+      "requires": {
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      }
     },
     "stable": {
       "version": "0.1.6",
@@ -859,6 +2070,27 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -876,15 +2108,18 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+      "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
     },
     "table-layout": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
-      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.3.tgz",
+      "integrity": "sha512-MIhflPM38ejKrFwWwC3P9x3eHvMo5G5AmNo29Qtz2HpBl5KD2GCcmOErjgNtUQLv/qaqVDagfJY3rJLPDvEgLg==",
       "dev": true,
       "requires": {
         "array-back": "2.0.0",
@@ -910,6 +2145,57 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -931,22 +2217,141 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
     },
-    "vscode-uri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g=",
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "use": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      }
+    },
+    "vscode-uri": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI=",
+      "dev": true
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "webmat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/webmat/-/webmat-0.2.0.tgz",
+      "integrity": "sha512-xf2iHrssbbTofFwxvrdtgSxILQ8ledlpeDc76fNkTEL76gGnxCB/YA69UF498+UPfYIDvVnk9Qt2E7MJOApacA==",
+      "dev": true,
+      "requires": {
+        "clang-format": "1.2.3",
+        "dom5": "3.0.0",
+        "fast-glob": "2.2.0",
+        "parse5": "4.0.0"
+      }
+    },
+    "whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
+    },
     "winston": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
+      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "dev": true,
       "requires": {
         "async": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@polymer/gen-typescript-declarations": "^1.1.1",
-    "bower": "^1.8.0"
+    "bower": "^1.8.0",
+    "webmat": "^0.2.0"
   },
   "scripts": {
-    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir ."
+    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir .",
+    "format": "webmat && npm run update-types"
   }
 }

--- a/paper-input-addon-behavior.d.ts
+++ b/paper-input-addon-behavior.d.ts
@@ -13,15 +13,17 @@
 declare namespace Polymer {
 
   /**
-   * Use `Polymer.PaperInputAddonBehavior` to implement an add-on for `<paper-input-container>`. A
-   * add-on appears below the input, and may display information based on the input value and
-   * validity such as a character counter or an error message.
+   * Use `Polymer.PaperInputAddonBehavior` to implement an add-on for
+   * `<paper-input-container>`. A add-on appears below the input, and may display
+   * information based on the input value and validity such as a character counter
+   * or an error message.
    */
   interface PaperInputAddonBehavior {
     attached(): void;
 
     /**
-     * The function called by `<paper-input-container>` when the input value or validity changes.
+     * The function called by `<paper-input-container>` when the input value or
+     * validity changes.
      *
      * @param state     inputElement: The input element.
      *     value: The input value.

--- a/paper-input-addon-behavior.html
+++ b/paper-input-addon-behavior.html
@@ -11,11 +11,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 
 <script>
-
   /**
-   * Use `Polymer.PaperInputAddonBehavior` to implement an add-on for `<paper-input-container>`. A
-   * add-on appears below the input, and may display information based on the input value and
-   * validity such as a character counter or an error message.
+   * Use `Polymer.PaperInputAddonBehavior` to implement an add-on for
+   * `<paper-input-container>`. A add-on appears below the input, and may display
+   * information based on the input value and validity such as a character counter
+   * or an error message.
    * @polymerBehavior
    */
   Polymer.PaperInputAddonBehavior = {
@@ -26,7 +26,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
-     * The function called by `<paper-input-container>` when the input value or validity changes.
+     * The function called by `<paper-input-container>` when the input value or
+     * validity changes.
      * @param {{
      *   invalid: boolean,
      *   inputElement: (Element|undefined),
@@ -36,9 +37,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *     value: The input value.
      *     invalid: True if the input value is invalid.
      */
-    update: function(state) {
-    }
+    update: function(state) {}
 
   };
-
 </script>

--- a/paper-input-behavior.d.ts
+++ b/paper-input-behavior.d.ts
@@ -15,13 +15,14 @@
 declare namespace Polymer {
 
   /**
-   * Use `Polymer.PaperInputBehavior` to implement inputs with `<paper-input-container>`. This
-   * behavior is implemented by `<paper-input>`. It exposes a number of properties from
-   * `<paper-input-container>` and `<input is="iron-input">` and they should be bound in your
-   * template.
+   * Use `Polymer.PaperInputBehavior` to implement inputs with
+   * `<paper-input-container>`. This behavior is implemented by `<paper-input>`.
+   * It exposes a number of properties from
+   * `<paper-input-container>` and `<input is="iron-input">` and they should be
+   * bound in your template.
    *
-   * The input element can be accessed by the `inputElement` property if you need to access
-   * properties or methods that are not exposed.
+   * The input element can be accessed by the `inputElement` property if you need
+   * to access properties or methods that are not exposed.
    */
   interface PaperInputBehavior extends Polymer.IronControlState, Polymer.IronA11yKeysBehavior {
 
@@ -50,12 +51,12 @@ declare namespace Polymer {
     value: string|null|undefined;
 
     /**
-     * Returns true if the value is invalid. If you're using PaperInputBehavior to
-     * implement your own paper-input-like element, bind this to both the
+     * Returns true if the value is invalid. If you're using PaperInputBehavior
+     * to implement your own paper-input-like element, bind this to both the
      * `<paper-input-container>`'s and the input's `invalid` property.
      *
-     * If `autoValidate` is true, the `invalid` attribute is managed automatically,
-     * which can clobber attempts to manage it manually.
+     * If `autoValidate` is true, the `invalid` attribute is managed
+     * automatically, which can clobber attempts to manage it manually.
      */
     invalid: boolean|null|undefined;
 
@@ -69,31 +70,34 @@ declare namespace Polymer {
 
     /**
      * The type of the input. The supported types are the
-     * [native input's types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_<input>_types).
-     * If you're using PaperInputBehavior to implement your own paper-input-like element,
-     * bind this to the (Polymer 1) `<input is="iron-input">`'s or (Polymer 2)
+     * [native input's
+     * types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_<input>_types).
+     * If you're using PaperInputBehavior to implement your own paper-input-like
+     * element, bind this to the (Polymer 1) `<input is="iron-input">`'s or
+     * (Polymer 2)
      * `<iron-input>`'s `type` property.
      */
     type: string|null|undefined;
 
     /**
-     * The datalist of the input (if any). This should match the id of an existing `<datalist>`.
-     * If you're using PaperInputBehavior to implement your own paper-input-like
-     * element, bind this to the `<input is="iron-input">`'s `list` property.
+     * The datalist of the input (if any). This should match the id of an
+     * existing `<datalist>`. If you're using PaperInputBehavior to implement
+     * your own paper-input-like element, bind this to the `<input
+     * is="iron-input">`'s `list` property.
      */
     list: string|null|undefined;
 
     /**
-     * A pattern to validate the `input` with. If you're using PaperInputBehavior to
-     * implement your own paper-input-like element, bind this to
-     * the `<input is="iron-input">`'s `pattern` property.
+     * A pattern to validate the `input` with. If you're using
+     * PaperInputBehavior to implement your own paper-input-like element, bind
+     * this to the `<input is="iron-input">`'s `pattern` property.
      */
     pattern: string|null|undefined;
 
     /**
-     * Set to true to mark the input as required. If you're using PaperInputBehavior to
-     * implement your own paper-input-like element, bind this to
-     * the `<input is="iron-input">`'s `required` property.
+     * Set to true to mark the input as required. If you're using
+     * PaperInputBehavior to implement your own paper-input-like element, bind
+     * this to the `<input is="iron-input">`'s `required` property.
      */
     required: boolean|null|undefined;
 
@@ -110,23 +114,23 @@ declare namespace Polymer {
     charCounter: boolean|null|undefined;
 
     /**
-     * Set to true to disable the floating label. If you're using PaperInputBehavior to
-     * implement your own paper-input-like element, bind this to
-     * the `<paper-input-container>`'s `noLabelFloat` property.
+     * Set to true to disable the floating label. If you're using
+     * PaperInputBehavior to implement your own paper-input-like element, bind
+     * this to the `<paper-input-container>`'s `noLabelFloat` property.
      */
     noLabelFloat: boolean|null|undefined;
 
     /**
-     * Set to true to always float the label. If you're using PaperInputBehavior to
-     * implement your own paper-input-like element, bind this to
-     * the `<paper-input-container>`'s `alwaysFloatLabel` property.
+     * Set to true to always float the label. If you're using PaperInputBehavior
+     * to implement your own paper-input-like element, bind this to the
+     * `<paper-input-container>`'s `alwaysFloatLabel` property.
      */
     alwaysFloatLabel: boolean|null|undefined;
 
     /**
-     * Set to true to auto-validate the input value. If you're using PaperInputBehavior to
-     * implement your own paper-input-like element, bind this to
-     * the `<paper-input-container>`'s `autoValidate` property.
+     * Set to true to auto-validate the input value. If you're using
+     * PaperInputBehavior to implement your own paper-input-like element, bind
+     * this to the `<paper-input-container>`'s `autoValidate` property.
      */
     autoValidate: boolean|null|undefined;
 
@@ -139,33 +143,38 @@ declare namespace Polymer {
 
     /**
      * If you're using PaperInputBehavior to implement your own paper-input-like
-     * element, bind this to the `<input is="iron-input">`'s `autocomplete` property.
+     * element, bind this to the `<input is="iron-input">`'s `autocomplete`
+     * property.
      */
     autocomplete: string|null|undefined;
 
     /**
      * If you're using PaperInputBehavior to implement your own paper-input-like
-     * element, bind this to the `<input is="iron-input">`'s `autofocus` property.
+     * element, bind this to the `<input is="iron-input">`'s `autofocus`
+     * property.
      */
     autofocus: boolean|null|undefined;
 
     /**
      * If you're using PaperInputBehavior to implement your own paper-input-like
-     * element, bind this to the `<input is="iron-input">`'s `inputmode` property.
+     * element, bind this to the `<input is="iron-input">`'s `inputmode`
+     * property.
      */
     inputmode: string|null|undefined;
 
     /**
      * The minimum length of the input value.
      * If you're using PaperInputBehavior to implement your own paper-input-like
-     * element, bind this to the `<input is="iron-input">`'s `minlength` property.
+     * element, bind this to the `<input is="iron-input">`'s `minlength`
+     * property.
      */
     minlength: number|null|undefined;
 
     /**
      * The maximum length of the input value.
      * If you're using PaperInputBehavior to implement your own paper-input-like
-     * element, bind this to the `<input is="iron-input">`'s `maxlength` property.
+     * element, bind this to the `<input is="iron-input">`'s `maxlength`
+     * property.
      */
     maxlength: number|null|undefined;
 
@@ -198,13 +207,15 @@ declare namespace Polymer {
     name: string|null|undefined;
 
     /**
-     * A placeholder string in addition to the label. If this is set, the label will always float.
+     * A placeholder string in addition to the label. If this is set, the label
+     * will always float.
      */
     placeholder: string|null|undefined;
 
     /**
      * If you're using PaperInputBehavior to implement your own paper-input-like
-     * element, bind this to the `<input is="iron-input">`'s `readonly` property.
+     * element, bind this to the `<input is="iron-input">`'s `readonly`
+     * property.
      */
     readonly: boolean|null|undefined;
 
@@ -216,20 +227,22 @@ declare namespace Polymer {
 
     /**
      * If you're using PaperInputBehavior to implement your own paper-input-like
-     * element, bind this to the `<input is="iron-input">`'s `autocapitalize` property.
+     * element, bind this to the `<input is="iron-input">`'s `autocapitalize`
+     * property.
      */
     autocapitalize: string|null|undefined;
 
     /**
      * If you're using PaperInputBehavior to implement your own paper-input-like
-     * element, bind this to the `<input is="iron-input">`'s `autocorrect` property.
+     * element, bind this to the `<input is="iron-input">`'s `autocorrect`
+     * property.
      */
     autocorrect: string|null|undefined;
 
     /**
      * If you're using PaperInputBehavior to implement your own paper-input-like
-     * element, bind this to the `<input is="iron-input">`'s `autosave` property,
-     * used with type=search.
+     * element, bind this to the `<input is="iron-input">`'s `autosave`
+     * property, used with type=search.
      */
     autosave: string|null|undefined;
 

--- a/paper-input-behavior.html
+++ b/paper-input-behavior.html
@@ -13,7 +13,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
 
 <script>
-
   // Generate unique, monotonically increasing IDs for labels (needed by
   // aria-labelledby) and add-ons.
   Polymer.PaperInputHelper = {};
@@ -22,13 +21,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.PaperInputHelper.NextInputID = 1;
 
   /**
-   * Use `Polymer.PaperInputBehavior` to implement inputs with `<paper-input-container>`. This
-   * behavior is implemented by `<paper-input>`. It exposes a number of properties from
-   * `<paper-input-container>` and `<input is="iron-input">` and they should be bound in your
-   * template.
+   * Use `Polymer.PaperInputBehavior` to implement inputs with
+   * `<paper-input-container>`. This behavior is implemented by `<paper-input>`.
+   * It exposes a number of properties from
+   * `<paper-input-container>` and `<input is="iron-input">` and they should be
+   * bound in your template.
    *
-   * The input element can be accessed by the `inputElement` property if you need to access
-   * properties or methods that are not exposed.
+   * The input element can be accessed by the `inputElement` property if you need
+   * to access properties or methods that are not exposed.
    * @polymerBehavior Polymer.PaperInputBehavior
    */
   Polymer.PaperInputBehaviorImpl = {
@@ -46,9 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * `<label>`'s content and `hidden` property, e.g.
        * `<label hidden$="[[!label]]">[[label]]</label>` in your `template`
        */
-      label: {
-        type: String
-      },
+      label: {type: String},
 
       /**
        * The value for this input. If you're using PaperInputBehavior to
@@ -56,34 +54,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * the `<iron-input>`'s `bindValue`
        * property, or the value property of your input that is `notify:true`.
        */
-      value: {
-        notify: true,
-        type: String
-      },
+      value: {notify: true, type: String},
 
       /**
        * Set to true to disable this input. If you're using PaperInputBehavior to
        * implement your own paper-input-like element, bind this to
        * both the `<paper-input-container>`'s and the input's `disabled` property.
        */
-      disabled: {
-        type: Boolean,
-        value: false
-      },
+      disabled: {type: Boolean, value: false},
 
       /**
-       * Returns true if the value is invalid. If you're using PaperInputBehavior to
-       * implement your own paper-input-like element, bind this to both the
+       * Returns true if the value is invalid. If you're using PaperInputBehavior
+       * to implement your own paper-input-like element, bind this to both the
        * `<paper-input-container>`'s and the input's `invalid` property.
        *
-       * If `autoValidate` is true, the `invalid` attribute is managed automatically,
-       * which can clobber attempts to manage it manually.
+       * If `autoValidate` is true, the `invalid` attribute is managed
+       * automatically, which can clobber attempts to manage it manually.
        */
-      invalid: {
-        type: Boolean,
-        value: false,
-        notify: true
-      },
+      invalid: {type: Boolean, value: false, notify: true},
 
       /**
        * Set this to specify the pattern allowed by `preventInvalidInput`. If
@@ -91,159 +79,126 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * element, bind this to the `<input is="iron-input">`'s `allowedPattern`
        * property.
        */
-      allowedPattern: {
-        type: String
-      },
+      allowedPattern: {type: String},
 
       /**
        * The type of the input. The supported types are the
-       * [native input's types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_<input>_types).
-       * If you're using PaperInputBehavior to implement your own paper-input-like element,
-       * bind this to the (Polymer 1) `<input is="iron-input">`'s or (Polymer 2)
+       * [native input's
+       * types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_<input>_types).
+       * If you're using PaperInputBehavior to implement your own paper-input-like
+       * element, bind this to the (Polymer 1) `<input is="iron-input">`'s or
+       * (Polymer 2)
        * `<iron-input>`'s `type` property.
        */
-      type: {
-        type: String
-      },
+      type: {type: String},
 
       /**
-       * The datalist of the input (if any). This should match the id of an existing `<datalist>`.
-       * If you're using PaperInputBehavior to implement your own paper-input-like
-       * element, bind this to the `<input is="iron-input">`'s `list` property.
+       * The datalist of the input (if any). This should match the id of an
+       * existing `<datalist>`. If you're using PaperInputBehavior to implement
+       * your own paper-input-like element, bind this to the `<input
+       * is="iron-input">`'s `list` property.
        */
-      list: {
-        type: String
-      },
+      list: {type: String},
 
       /**
-       * A pattern to validate the `input` with. If you're using PaperInputBehavior to
-       * implement your own paper-input-like element, bind this to
-       * the `<input is="iron-input">`'s `pattern` property.
+       * A pattern to validate the `input` with. If you're using
+       * PaperInputBehavior to implement your own paper-input-like element, bind
+       * this to the `<input is="iron-input">`'s `pattern` property.
        */
-      pattern: {
-        type: String
-      },
+      pattern: {type: String},
 
       /**
-       * Set to true to mark the input as required. If you're using PaperInputBehavior to
-       * implement your own paper-input-like element, bind this to
-       * the `<input is="iron-input">`'s `required` property.
+       * Set to true to mark the input as required. If you're using
+       * PaperInputBehavior to implement your own paper-input-like element, bind
+       * this to the `<input is="iron-input">`'s `required` property.
        */
-      required: {
-        type: Boolean,
-        value: false
-      },
+      required: {type: Boolean, value: false},
 
       /**
        * The error message to display when the input is invalid. If you're using
        * PaperInputBehavior to implement your own paper-input-like element,
        * bind this to the `<paper-input-error>`'s content, if using.
        */
-      errorMessage: {
-        type: String
-      },
+      errorMessage: {type: String},
 
       /**
        * Set to true to show a character counter.
        */
-      charCounter: {
-        type: Boolean,
-        value: false
-      },
+      charCounter: {type: Boolean, value: false},
 
       /**
-       * Set to true to disable the floating label. If you're using PaperInputBehavior to
-       * implement your own paper-input-like element, bind this to
-       * the `<paper-input-container>`'s `noLabelFloat` property.
+       * Set to true to disable the floating label. If you're using
+       * PaperInputBehavior to implement your own paper-input-like element, bind
+       * this to the `<paper-input-container>`'s `noLabelFloat` property.
        */
-      noLabelFloat: {
-        type: Boolean,
-        value: false
-      },
+      noLabelFloat: {type: Boolean, value: false},
 
       /**
-       * Set to true to always float the label. If you're using PaperInputBehavior to
-       * implement your own paper-input-like element, bind this to
-       * the `<paper-input-container>`'s `alwaysFloatLabel` property.
+       * Set to true to always float the label. If you're using PaperInputBehavior
+       * to implement your own paper-input-like element, bind this to the
+       * `<paper-input-container>`'s `alwaysFloatLabel` property.
        */
-      alwaysFloatLabel: {
-        type: Boolean,
-        value: false
-      },
+      alwaysFloatLabel: {type: Boolean, value: false},
 
       /**
-       * Set to true to auto-validate the input value. If you're using PaperInputBehavior to
-       * implement your own paper-input-like element, bind this to
-       * the `<paper-input-container>`'s `autoValidate` property.
+       * Set to true to auto-validate the input value. If you're using
+       * PaperInputBehavior to implement your own paper-input-like element, bind
+       * this to the `<paper-input-container>`'s `autoValidate` property.
        */
-      autoValidate: {
-        type: Boolean,
-        value: false
-      },
+      autoValidate: {type: Boolean, value: false},
 
       /**
        * Name of the validator to use. If you're using PaperInputBehavior to
        * implement your own paper-input-like element, bind this to
        * the `<input is="iron-input">`'s `validator` property.
        */
-      validator: {
-        type: String
-      },
+      validator: {type: String},
 
       // HTMLInputElement attributes for binding if needed
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
-       * element, bind this to the `<input is="iron-input">`'s `autocomplete` property.
+       * element, bind this to the `<input is="iron-input">`'s `autocomplete`
+       * property.
        */
-      autocomplete: {
-        type: String,
-        value: 'off'
-      },
+      autocomplete: {type: String, value: 'off'},
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
-       * element, bind this to the `<input is="iron-input">`'s `autofocus` property.
+       * element, bind this to the `<input is="iron-input">`'s `autofocus`
+       * property.
        */
-      autofocus: {
-        type: Boolean,
-        observer: '_autofocusChanged'
-      },
+      autofocus: {type: Boolean, observer: '_autofocusChanged'},
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
-       * element, bind this to the `<input is="iron-input">`'s `inputmode` property.
+       * element, bind this to the `<input is="iron-input">`'s `inputmode`
+       * property.
        */
-      inputmode: {
-        type: String
-      },
+      inputmode: {type: String},
 
       /**
        * The minimum length of the input value.
        * If you're using PaperInputBehavior to implement your own paper-input-like
-       * element, bind this to the `<input is="iron-input">`'s `minlength` property.
+       * element, bind this to the `<input is="iron-input">`'s `minlength`
+       * property.
        */
-      minlength: {
-        type: Number
-      },
+      minlength: {type: Number},
 
       /**
        * The maximum length of the input value.
        * If you're using PaperInputBehavior to implement your own paper-input-like
-       * element, bind this to the `<input is="iron-input">`'s `maxlength` property.
+       * element, bind this to the `<input is="iron-input">`'s `maxlength`
+       * property.
        */
-      maxlength: {
-        type: Number
-      },
+      maxlength: {type: Number},
 
       /**
        * The minimum (numeric or date-time) input value.
        * If you're using PaperInputBehavior to implement your own paper-input-like
        * element, bind this to the `<input is="iron-input">`'s `min` property.
        */
-      min: {
-        type: String
-      },
+      min: {type: String},
 
       /**
        * The maximum (numeric or date-time) input value.
@@ -251,29 +206,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * If you're using PaperInputBehavior to implement your own paper-input-like
        * element, bind this to the `<input is="iron-input">`'s `max` property.
        */
-      max: {
-        type: String
-      },
+      max: {type: String},
 
       /**
        * Limits the numeric or date-time increments.
        * If you're using PaperInputBehavior to implement your own paper-input-like
        * element, bind this to the `<input is="iron-input">`'s `step` property.
        */
-      step: {
-        type: String
-      },
+      step: {type: String},
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
        * element, bind this to the `<input is="iron-input">`'s `name` property.
        */
-      name: {
-        type: String
-      },
+      name: {type: String},
 
       /**
-       * A placeholder string in addition to the label. If this is set, the label will always float.
+       * A placeholder string in addition to the label. If this is set, the label
+       * will always float.
        */
       placeholder: {
         type: String,
@@ -283,94 +233,69 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
-       * element, bind this to the `<input is="iron-input">`'s `readonly` property.
+       * element, bind this to the `<input is="iron-input">`'s `readonly`
+       * property.
        */
-      readonly: {
-        type: Boolean,
-        value: false
-      },
+      readonly: {type: Boolean, value: false},
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
        * element, bind this to the `<input is="iron-input">`'s `size` property.
        */
-      size: {
-        type: Number
-      },
+      size: {type: Number},
 
       // Nonstandard attributes for binding if needed
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
-       * element, bind this to the `<input is="iron-input">`'s `autocapitalize` property.
+       * element, bind this to the `<input is="iron-input">`'s `autocapitalize`
+       * property.
        */
-      autocapitalize: {
-        type: String,
-        value: 'none'
-      },
+      autocapitalize: {type: String, value: 'none'},
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
-       * element, bind this to the `<input is="iron-input">`'s `autocorrect` property.
+       * element, bind this to the `<input is="iron-input">`'s `autocorrect`
+       * property.
        */
-      autocorrect: {
-        type: String,
-        value: 'off'
-      },
+      autocorrect: {type: String, value: 'off'},
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
-       * element, bind this to the `<input is="iron-input">`'s `autosave` property,
-       * used with type=search.
+       * element, bind this to the `<input is="iron-input">`'s `autosave`
+       * property, used with type=search.
        */
-      autosave: {
-        type: String
-      },
+      autosave: {type: String},
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
        * element, bind this to the `<input is="iron-input">`'s `results` property,
        * used with type=search.
        */
-      results: {
-        type: Number
-      },
+      results: {type: Number},
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
        * element, bind this to the `<input is="iron-input">`'s `accept` property,
        * used with type=file.
        */
-      accept: {
-        type: String
-      },
+      accept: {type: String},
 
       /**
        * If you're using PaperInputBehavior to implement your own paper-input-like
        * element, bind this to the`<input is="iron-input">`'s `multiple` property,
        * used with type=file.
        */
-      multiple: {
-        type: Boolean
-      },
+      multiple: {type: Boolean},
 
       /** @private */
-      _ariaDescribedBy: {
-        type: String,
-        value: ''
-      },
+      _ariaDescribedBy: {type: String, value: ''},
 
       /** @private */
-      _ariaLabelledBy: {
-        type: String,
-        value: ''
-      },
+      _ariaLabelledBy: {type: String, value: ''},
 
       /** @private */
-      _inputId: {
-        type: String,
-        value: ''
-      }
+      _inputId: {type: String, value: ''}
     },
 
     listeners: {
@@ -380,14 +305,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * @type {!Object}
      */
-    keyBindings: {
-      'shift+tab:keydown': '_onShiftTabDown'
-    },
+    keyBindings: {'shift+tab:keydown': '_onShiftTabDown'},
 
     /** @private */
-    hostAttributes: {
-      tabindex: 0
-    },
+    hostAttributes: {tabindex: 0},
 
     /**
      * Returns a reference to the input element.
@@ -418,16 +339,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     created: function() {
       // These types have some default placeholder text; overlapping
       // the label on top of it looks terrible. Auto-float the label in this case.
-      this._typesThatHaveText = ["date", "datetime", "datetime-local", "month",
-          "time", "week", "file"];
+      this._typesThatHaveText =
+          ['date', 'datetime', 'datetime-local', 'month', 'time', 'week', 'file'];
     },
 
     attached: function() {
       this._updateAriaLabelledBy();
 
       // In the 2.0 version of the element, this is handled in `onIronInputReady`,
-      // i.e. after the native input has finished distributing. In the 1.0 version,
-      // the input is in the shadow tree, so it's already available.
+      // i.e. after the native input has finished distributing. In the 1.0
+      // version, the input is in the shadow tree, so it's already available.
       if (!Polymer.Element && this.inputElement &&
           this._typesThatHaveText.indexOf(this.inputElement.type) !== -1) {
         this.alwaysFloatLabel = true;
@@ -446,11 +367,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _onAddonAttached: function(event) {
       var target = Polymer.dom(event).rootTarget;
       if (target.id) {
-        this._ariaDescribedBy = this._appendStringWithSpace(this._ariaDescribedBy, target.id);
+        this._ariaDescribedBy =
+            this._appendStringWithSpace(this._ariaDescribedBy, target.id);
       } else {
         var id = 'paper-input-add-on-' + Polymer.PaperInputHelper.NextAddonID++;
         target.id = id;
-        this._ariaDescribedBy = this._appendStringWithSpace(this._ariaDescribedBy, id);
+        this._ariaDescribedBy =
+            this._appendStringWithSpace(this._ariaDescribedBy, id);
       }
     },
 
@@ -534,7 +457,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (label.id) {
         labelledBy = label.id;
       } else {
-        labelledBy = 'paper-input-label-' + Polymer.PaperInputHelper.NextLabelID++;
+        labelledBy =
+            'paper-input-label-' + Polymer.PaperInputHelper.NextLabelID++;
         label.id = labelledBy;
       }
       this._ariaLabelledBy = labelledBy;
@@ -542,20 +466,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _generateInputId: function() {
       if (!this._inputId || this._inputId === '') {
-        this._inputId =  'input-' + Polymer.PaperInputHelper.NextInputID++;
+        this._inputId = 'input-' + Polymer.PaperInputHelper.NextInputID++;
       }
     },
 
-    _onChange:function(event) {
+    _onChange: function(event) {
       // In the Shadow DOM, the `change` event is not leaked into the
       // ancestor tree, so we must do this manually.
-      // See https://w3c.github.io/webcomponents/spec/shadow/#events-that-are-not-leaked-into-ancestor-trees.
+      // See
+      // https://w3c.github.io/webcomponents/spec/shadow/#events-that-are-not-leaked-into-ancestor-trees.
       if (this.shadowRoot) {
-        this.fire(event.type, {sourceEvent: event}, {
-          node: this,
-          bubbles: event.bubbles,
-          cancelable: event.cancelable
-        });
+        this.fire(
+            event.type,
+            {sourceEvent: event},
+            {node: this, bubbles: event.bubbles, cancelable: event.cancelable});
       }
     },
 
@@ -566,7 +490,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // element is upgraded. As a workaround, if the autofocus property is set,
       // and the focus hasn't already been moved elsewhere, we take focus.
       if (this.autofocus && this._focusableElement) {
-
         // In IE 11, the default document.activeElement can be the page's
         // outermost html element, but there are also cases (under the
         // polyfill?) in which the activeElement is not a real HTMLElement, but

--- a/paper-input-char-counter.html
+++ b/paper-input-char-counter.html
@@ -58,16 +58,9 @@ Custom property | Description | Default
   Polymer({
     is: 'paper-input-char-counter',
 
-    behaviors: [
-      Polymer.PaperInputAddonBehavior
-    ],
+    behaviors: [Polymer.PaperInputAddonBehavior],
 
-    properties: {
-      _charCounterStr: {
-        type: String,
-        value: '0'
-      }
-    },
+    properties: {_charCounterStr: {type: String, value: '0'}},
 
     /**
      * This overrides the update function in PaperInputAddonBehavior.

--- a/paper-input-container.d.ts
+++ b/paper-input-container.d.ts
@@ -16,8 +16,8 @@
 interface PaperInputContainerElement extends Polymer.Element {
 
   /**
-   * Set to true to disable the floating label. The label disappears when the input value is
-   * not null.
+   * Set to true to disable the floating label. The label disappears when the
+   * input value is not null.
    */
   noLabelFloat: boolean|null|undefined;
 
@@ -37,8 +37,9 @@ interface PaperInputContainerElement extends Polymer.Element {
   autoValidate: boolean|null|undefined;
 
   /**
-   * True if the input is invalid. This property is set automatically when the input value
-   * changes if auto-validating, or when the `iron-input-validate` event is heard from a child.
+   * True if the input is invalid. This property is set automatically when the
+   * input value changes if auto-validating, or when the `iron-input-validate`
+   * event is heard from a child.
    */
   invalid: boolean|null|undefined;
 

--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -390,74 +390,49 @@ This element is `display:block` by default, but you can set the `inline` attribu
 
     properties: {
       /**
-       * Set to true to disable the floating label. The label disappears when the input value is
-       * not null.
+       * Set to true to disable the floating label. The label disappears when the
+       * input value is not null.
        */
-      noLabelFloat: {
-        type: Boolean,
-        value: false
-      },
+      noLabelFloat: {type: Boolean, value: false},
 
       /**
        * Set to true to always float the floating label.
        */
-      alwaysFloatLabel: {
-        type: Boolean,
-        value: false
-      },
+      alwaysFloatLabel: {type: Boolean, value: false},
 
       /**
        * The attribute to listen for value changes on.
        */
-      attrForValue: {
-        type: String,
-        value: 'bind-value'
-      },
+      attrForValue: {type: String, value: 'bind-value'},
 
       /**
        * Set to true to auto-validate the input value when it changes.
        */
-      autoValidate: {
-        type: Boolean,
-        value: false
-      },
+      autoValidate: {type: Boolean, value: false},
 
       /**
-       * True if the input is invalid. This property is set automatically when the input value
-       * changes if auto-validating, or when the `iron-input-validate` event is heard from a child.
+       * True if the input is invalid. This property is set automatically when the
+       * input value changes if auto-validating, or when the `iron-input-validate`
+       * event is heard from a child.
        */
-      invalid: {
-        observer: '_invalidChanged',
-        type: Boolean,
-        value: false
-      },
+      invalid: {observer: '_invalidChanged', type: Boolean, value: false},
 
       /**
        * True if the input has focus.
        */
-      focused: {
-        readOnly: true,
-        type: Boolean,
-        value: false,
-        notify: true
-      },
+      focused: {readOnly: true, type: Boolean, value: false, notify: true},
 
       _addons: {
         type: Array
-        // do not set a default value here intentionally - it will be initialized lazily when a
-        // distributed child is attached, which may occur before configuration for this element
-        // in polyfill.
+        // do not set a default value here intentionally - it will be initialized
+        // lazily when a distributed child is attached, which may occur before
+        // configuration for this element in polyfill.
       },
 
-      _inputHasContent: {
-        type: Boolean,
-        value: false
-      },
+      _inputHasContent: {type: Boolean, value: false},
 
-      _inputSelector: {
-        type: String,
-        value: 'input,iron-input,textarea,.paper-input-input'
-      },
+      _inputSelector:
+          {type: String, value: 'input,iron-input,textarea,.paper-input-input'},
 
       _boundOnFocus: {
         type: Function,
@@ -506,15 +481,17 @@ This element is `display:block` by default, but you can set the `inline` attribu
     },
 
     get _inputElementValue() {
-      return this._inputElement[this._propertyForValue] || this._inputElement.value;
+      return this._inputElement[this._propertyForValue] ||
+          this._inputElement.value;
     },
 
     ready: function() {
       // Paper-input treats a value of undefined differently at startup than
-      // the rest of the time (specifically: it does not validate it at startup, but
-      // it does after that. We need to track whether the first time we encounter
-      // the value is basically this first time, so that we can validate it
-      // correctly the rest of the time. See https://github.com/PolymerElements/paper-input/issues/605
+      // the rest of the time (specifically: it does not validate it at startup,
+      // but it does after that. We need to track whether the first time we
+      // encounter the value is basically this first time, so that we can validate
+      // it correctly the rest of the time. See
+      // https://github.com/PolymerElements/paper-input/issues/605
       this.__isFirstValueUpdate = true;
       if (!this._addons) {
         this._addons = [];
@@ -525,7 +502,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
 
     attached: function() {
       if (this.attrForValue) {
-        this._inputElement.addEventListener(this._valueChangedEvent, this._boundValueChanged);
+        this._inputElement.addEventListener(
+            this._valueChangedEvent, this._boundValueChanged);
       } else {
         this.addEventListener('input', this._onInput);
       }
@@ -573,9 +551,9 @@ This element is `display:block` by default, but you can set the `inline` attribu
       var input = event.target;
 
       // Paper-input treats a value of undefined differently at startup than
-      // the rest of the time (specifically: it does not validate it at startup, but
-      // it does after that. If this is in fact the bootup case, ignore validation,
-      // just this once.
+      // the rest of the time (specifically: it does not validate it at startup,
+      // but it does after that. If this is in fact the bootup case, ignore
+      // validation, just this once.
       if (this.__isFirstValueUpdate) {
         this.__isFirstValueUpdate = false;
         if (input.value === undefined) {
@@ -591,17 +569,15 @@ This element is `display:block` by default, but you can set the `inline` attribu
       var value = this._inputElementValue;
 
       // type="number" hack needed because this.value is empty until it's valid
-      if (value || value === 0 || (inputElement.type === 'number' && !inputElement.checkValidity())) {
+      if (value || value === 0 ||
+          (inputElement.type === 'number' && !inputElement.checkValidity())) {
         this._inputHasContent = true;
       } else {
         this._inputHasContent = false;
       }
 
-      this.updateAddons({
-        inputElement: inputElement,
-        value: value,
-        invalid: this.invalid
-      });
+      this.updateAddons(
+          {inputElement: inputElement, value: value, invalid: this.invalid});
     },
 
     /** @private */
@@ -644,7 +620,8 @@ This element is `display:block` by default, but you can set the `inline` attribu
     },
 
     /** @private */
-    _computeInputContentClass: function(noLabelFloat, alwaysFloatLabel, focused, invalid, _inputHasContent) {
+    _computeInputContentClass: function(
+        noLabelFloat, alwaysFloatLabel, focused, invalid, _inputHasContent) {
       var cls = 'input-content';
       if (!noLabelFloat) {
         var label = this.querySelector('label');
@@ -658,7 +635,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
           if (invalid) {
             cls += ' is-invalid';
           } else if (focused) {
-            cls += " label-is-highlighted";
+            cls += ' label-is-highlighted';
           }
         } else {
           // When the label is not floating, it should overlap the input element.

--- a/paper-input-error.html
+++ b/paper-input-error.html
@@ -61,19 +61,13 @@ Custom property | Description | Default
   Polymer({
     is: 'paper-input-error',
 
-    behaviors: [
-      Polymer.PaperInputAddonBehavior
-    ],
+    behaviors: [Polymer.PaperInputAddonBehavior],
 
     properties: {
       /**
        * True if the error is showing.
        */
-      invalid: {
-        readOnly: true,
-        reflectToAttribute: true,
-        type: Boolean
-      }
+      invalid: {readOnly: true, reflectToAttribute: true, type: Boolean}
     },
 
     /**

--- a/paper-input.d.ts
+++ b/paper-input.d.ts
@@ -69,8 +69,8 @@
 interface PaperInputElement extends Polymer.Element, Polymer.PaperInputBehavior, Polymer.IronFormElementBehavior {
 
   /**
-   * Returns a reference to the focusable element. Overridden from PaperInputBehavior
-   * to correctly focus the native input.
+   * Returns a reference to the focusable element. Overridden from
+   * PaperInputBehavior to correctly focus the native input.
    */
   readonly _focusableElement: HTMLElement;
   beforeRegister(): void;

--- a/paper-input.html
+++ b/paper-input.html
@@ -272,10 +272,7 @@ Custom property | Description | Default
   Polymer({
     is: 'paper-input',
 
-    behaviors: [
-      Polymer.PaperInputBehavior,
-      Polymer.IronFormElementBehavior
-    ],
+    behaviors: [Polymer.PaperInputBehavior, Polymer.IronFormElementBehavior],
 
     beforeRegister: function() {
       // We need to tell which kind of of template to stamp based on
@@ -284,32 +281,35 @@ Custom property | Description | Default
       // to check a particular method we know the iron-input#2.x can have.
       // If it doesn't have it, then it's an iron-input#1.x.
       var ironInput = document.createElement('iron-input');
-      var version = typeof ironInput._initSlottedInput == 'function' ? 'v1' : 'v0';
+      var version =
+          typeof ironInput._initSlottedInput == 'function' ? 'v1' : 'v0';
       var template = Polymer.DomModule.import('paper-input', 'template');
-      var inputTemplate = Polymer.DomModule.import('paper-input', 'template#' + version);
-      var inputPlaceholder = template.content.querySelector('#template-placeholder');
+      var inputTemplate =
+          Polymer.DomModule.import('paper-input', 'template#' + version);
+      var inputPlaceholder =
+          template.content.querySelector('#template-placeholder');
       if (inputPlaceholder) {
-        inputPlaceholder.parentNode.replaceChild(inputTemplate.content, inputPlaceholder);
+        inputPlaceholder.parentNode.replaceChild(
+            inputTemplate.content, inputPlaceholder);
       }
       // else it's already been processed, probably in superclass
     },
 
     /**
-     * Returns a reference to the focusable element. Overridden from PaperInputBehavior
-     * to correctly focus the native input.
+     * Returns a reference to the focusable element. Overridden from
+     * PaperInputBehavior to correctly focus the native input.
      *
      * @return {!HTMLElement}
      */
     get _focusableElement() {
-      return Polymer.Element ? this.inputElement._inputElement : this.inputElement;
+      return Polymer.Element ? this.inputElement._inputElement :
+                               this.inputElement;
     },
 
     // Note: This event is only available in the 1.0 version of this element.
     // In 2.0, the functionality of `_onIronInputReady` is done in
     // PaperInputBehavior::attached.
-    listeners: {
-      'iron-input-ready': '_onIronInputReady'
-    },
+    listeners: {'iron-input-ready': '_onIronInputReady'},
 
     _onIronInputReady: function() {
       // Even though this is only used in the next line, save this for

--- a/test/letters-only.html
+++ b/test/letters-only.html
@@ -12,19 +12,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../iron-validator-behavior/iron-validator-behavior.html">
 
 <script>
-
   Polymer({
 
     is: 'letters-only',
 
-    behaviors: [
-      Polymer.IronValidatorBehavior
-    ],
+    behaviors: [Polymer.IronValidatorBehavior],
 
     validate: function(value) {
       return !value || value.match(/^[a-zA-Z]*$/) !== null;
     }
 
   });
-
 </script>

--- a/test/paper-input-char-counter.html
+++ b/test/paper-input-char-counter.html
@@ -63,55 +63,72 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <script>
-
     suite('basic', function() {
-
       test('character counter shows the value length', function() {
         var container = fixture('counter');
         var input = Polymer.dom(container).querySelector('#i');
         var counter = Polymer.dom(container).querySelector('#c');
-        assert.equal(counter._charCounterStr, input.value.length, 'character counter shows input value length');
+        assert.equal(
+            counter._charCounterStr,
+            input.value.length,
+            'character counter shows input value length');
       });
 
-      test('character counter shows the value length with maxlength', function(done) {
-        var container = fixture('counter-with-max');
+      test(
+          'character counter shows the value length with maxlength',
+          function(done) {
+            var container = fixture('counter-with-max');
 
-        // Need to wait a tick to stamp the char-counter.
-        Polymer.Base.async(function() {
-          var input = Polymer.dom(container).querySelector('#i');
-          var counter = Polymer.dom(container).querySelector('#c');
-          assert.equal(counter._charCounterStr, input.value.length + '/' + input.maxLength, 'character counter shows input value length and maxLength');
-          done();
-        }, 1);
-      });
+            // Need to wait a tick to stamp the char-counter.
+            Polymer.Base.async(function() {
+              var input = Polymer.dom(container).querySelector('#i');
+              var counter = Polymer.dom(container).querySelector('#c');
+              assert.equal(
+                  counter._charCounterStr,
+                  input.value.length + '/' + input.maxLength,
+                  'character counter shows input value length and maxLength');
+              done();
+            }, 1);
+          });
 
-      test('character counter shows the value length with maxlength', function(done) {
-        var input = fixture('textarea-with-max');
+      test(
+          'character counter shows the value length with maxlength',
+          function(done) {
+            var input = fixture('textarea-with-max');
 
-        // Need to wait a tick to stamp the char-counter.
-        Polymer.Base.async(function() {
-          var counter = Polymer.dom(input.root).querySelector('paper-input-char-counter');
-          assert.ok(counter, 'paper-input-char-counter exists');
-          assert.equal(counter._charCounterStr, input.value.length + '/' + input.inputElement.textarea.getAttribute('maxlength'), 'character counter shows input value length and maxLength');
-          done();
-        }, 1);
-      });
+            // Need to wait a tick to stamp the char-counter.
+            Polymer.Base.async(function() {
+              var counter =
+                  Polymer.dom(input.root).querySelector('paper-input-char-counter');
+              assert.ok(counter, 'paper-input-char-counter exists');
+              assert.equal(
+                  counter._charCounterStr,
+                  input.value.length + '/' +
+                      input.inputElement.textarea.getAttribute('maxlength'),
+                  'character counter shows input value length and maxLength');
+              done();
+            }, 1);
+          });
 
-      test('character counter counts new lines in textareas correctly', function(done) {
-        var input = fixture('textarea');
-        input.value = 'foo\nbar';
+      test(
+          'character counter counts new lines in textareas correctly',
+          function(done) {
+            var input = fixture('textarea');
+            input.value = 'foo\nbar';
 
-        // Need to wait a tick to stamp the char-counter.
-        Polymer.Base.async(function() {
-          var counter = Polymer.dom(input.root).querySelector('paper-input-char-counter')
-          assert.ok(counter, 'paper-input-char-counter exists');
-          assert.equal(counter._charCounterStr, input.value.length, 'character counter shows the value length');
-          done();
-        }, 1);
-      });
-
+            // Need to wait a tick to stamp the char-counter.
+            Polymer.Base.async(function() {
+              var counter =
+                  Polymer.dom(input.root).querySelector('paper-input-char-counter')
+              assert.ok(counter, 'paper-input-char-counter exists');
+              assert.equal(
+                  counter._charCounterStr,
+                  input.value.length,
+                  'character counter shows the value length');
+              done();
+            }, 1);
+          });
     });
-
   </script>
 
 </body>

--- a/test/paper-input-container.html
+++ b/test/paper-input-container.html
@@ -211,7 +211,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <script>
-
     function getTransform(node) {
       var style = getComputedStyle(node);
       return style.transform || style.webkitTransform;
@@ -237,28 +236,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('label position', function() {
-
       test('label is visible by default', function() {
         var container = fixture('basic');
-        assert.equal(getComputedStyle(container.querySelector('#l')).visibility, 'visible', 'label has visibility:visible');
+        assert.equal(
+            getComputedStyle(container.querySelector('#l')).visibility,
+            'visible',
+            'label has visibility:visible');
       });
 
       test('label is floated if value is initialized to not null', function(done) {
         var container = fixture('has-value');
         requestAnimationFrame(function() {
-          assert.notEqual(getTransform(container.querySelector('#l')), 'none', 'label has transform');
+          assert.notEqual(
+              getTransform(container.querySelector('#l')),
+              'none',
+              'label has transform');
           done();
         });
       });
 
-      test('label is invisible if no-label-float and value is initialized to not null', function() {
-        var container = fixture('no-float-has-value');
-        assert.equal(getComputedStyle(container.querySelector('#l')).visibility, 'hidden', 'label has visibility:hidden');
-      });
+      test(
+          'label is invisible if no-label-float and value is initialized to not null',
+          function() {
+            var container = fixture('no-float-has-value');
+            assert.equal(
+                getComputedStyle(container.querySelector('#l')).visibility,
+                'hidden',
+                'label has visibility:hidden');
+          });
 
       test('label is floated if always-float-label is true', function() {
         var container = fixture('always-float');
-        assert.notEqual(getTransform(container.querySelector('#l')), 'none', 'label has transform');
+        assert.notEqual(
+            getTransform(container.querySelector('#l')),
+            'none',
+            'label has transform');
       });
 
       test('label is floated correctly with a prefix', function(done) {
@@ -267,67 +279,86 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var input = Polymer.dom(container).querySelector('#i');
 
         // Label is initially visible.
-        assert.equal(getComputedStyle(label).visibility, 'visible', 'label has visibility:visible');
+        assert.equal(
+            getComputedStyle(label).visibility,
+            'visible',
+            'label has visibility:visible');
 
         // After entering text, the label floats, and it is not indented.
         input.bindValue = 'foobar';
         requestAnimationFrame(function() {
           assert.notEqual(getTransform(label), 'none', 'label has transform');
-          assert.equal(label.getBoundingClientRect().left, container.getBoundingClientRect().left);
+          assert.equal(
+              label.getBoundingClientRect().left,
+              container.getBoundingClientRect().left);
           done();
         });
       });
 
-      test('label is floated correctly with a prefix and prefilled value', function(done) {
-        var container = Polymer.Element ?
-            fixture('prefix-has-value-2') : fixture('prefix-has-value-1');
-        var label = Polymer.dom(container).querySelector('#l');
+      test(
+          'label is floated correctly with a prefix and prefilled value',
+          function(done) {
+            var container = Polymer.Element ? fixture('prefix-has-value-2') :
+                                              fixture('prefix-has-value-1');
+            var label = Polymer.dom(container).querySelector('#l');
 
-        // The label floats, and it is not indented.
-        requestAnimationFrame(function() {
-          assert.notEqual(getTransform(label), 'none', 'label has transform');
-          assert.equal(label.getBoundingClientRect().left, container.getBoundingClientRect().left);
-          done();
-        });
-      });
-
+            // The label floats, and it is not indented.
+            requestAnimationFrame(function() {
+              assert.notEqual(getTransform(label), 'none', 'label has transform');
+              assert.equal(
+                  label.getBoundingClientRect().left,
+                  container.getBoundingClientRect().left);
+              done();
+            });
+          });
     });
 
     suite('focused styling', function() {
-
       test('label is colored when input is focused and has value', function(done) {
         var container = fixture('has-value');
         var label = Polymer.dom(container).querySelector('#l');
         var input = Polymer.dom(container).querySelector('#i');
-        var inputContent = Polymer.dom(container.root).querySelector('.input-content');
+        var inputContent =
+            Polymer.dom(container.root).querySelector('.input-content');
         MockInteractions.focus(input);
         requestAnimationFrame(function() {
           assert.isTrue(container.focused, 'focused is true');
-          assert.isTrue(inputContent.classList.contains('label-is-highlighted'), 'label is highlighted when input has focus');
+          assert.isTrue(
+              inputContent.classList.contains('label-is-highlighted'),
+              'label is highlighted when input has focus');
           done();
         });
       });
 
-      test('label is not colored when input is focused and has null value', function(done) {
-        var container = fixture('basic');
-        var label = Polymer.dom(container).querySelector('#l');
-        var input = Polymer.dom(container).querySelector('#i');
-        var inputContent = Polymer.dom(container.root).querySelector('.input-content');
-        MockInteractions.focus(input);
-        requestAnimationFrame(function() {
-          assert.isFalse(inputContent.classList.contains('label-is-highlighted'), 'label is not highlighted when input has focus and has null value');
-          done();
-        });
-      });
+      test(
+          'label is not colored when input is focused and has null value',
+          function(done) {
+            var container = fixture('basic');
+            var label = Polymer.dom(container).querySelector('#l');
+            var input = Polymer.dom(container).querySelector('#i');
+            var inputContent =
+                Polymer.dom(container.root).querySelector('.input-content');
+            MockInteractions.focus(input);
+            requestAnimationFrame(function() {
+              assert.isFalse(
+                  inputContent.classList.contains('label-is-highlighted'),
+                  'label is not highlighted when input has focus and has null value');
+              done();
+            });
+          });
 
       test('underline is colored when input is focused', function(done) {
         var container = fixture('basic');
         var input = Polymer.dom(container).querySelector('#i');
         var line = Polymer.dom(container.root).querySelector('.underline');
-        assert.isFalse(line.classList.contains('is-highlighted'), 'line is not highlighted when input is not focused');
+        assert.isFalse(
+            line.classList.contains('is-highlighted'),
+            'line is not highlighted when input is not focused');
         MockInteractions.focus(input);
         requestAnimationFrame(function() {
-          assert.isTrue(line.classList.contains('is-highlighted'), 'line is highlighted when input is focused');
+          assert.isTrue(
+              line.classList.contains('is-highlighted'),
+              'line is highlighted when input is focused');
           done();
         });
       });
@@ -335,114 +366,146 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('focused class added to input content', function(done) {
         var container = fixture('basic');
         var input = Polymer.dom(container).querySelector('#i');
-        var inputContent = Polymer.dom(container.root).querySelector('.input-content');
-        assert.isFalse(inputContent.classList.contains('focused'), 'input content does not have class "focused" when input is not focused');
+        var inputContent =
+            Polymer.dom(container.root).querySelector('.input-content');
+        assert.isFalse(
+            inputContent.classList.contains('focused'),
+            'input content does not have class "focused" when input is not focused');
         MockInteractions.focus(input);
         requestAnimationFrame(function() {
-          assert.isTrue(inputContent.classList.contains('focused'), 'input content has class "focused" when input is focused');
+          assert.isTrue(
+              inputContent.classList.contains('focused'),
+              'input content has class "focused" when input is focused');
           done();
         });
       });
-
     });
 
     suite('validation', function() {
+      test(
+          'styled when the input is set to an invalid value with auto-validate',
+          function(done) {
+            var container = Polymer.Element ? fixture('auto-validate-numbers-2') :
+                                              fixture('auto-validate-numbers-1');
 
-      test('styled when the input is set to an invalid value with auto-validate', function(done) {
-        var container = Polymer.Element ?
-            fixture('auto-validate-numbers-2') :
-            fixture('auto-validate-numbers-1');
+            // Mutation observer is async, so wait one tick.
+            Polymer.Base.async(function() {
+              var input = Polymer.dom(container).querySelector('#i');
+              var inputContent =
+                  Polymer.dom(container.root).querySelector('.input-content');
+              var line = Polymer.dom(container.root).querySelector('.underline');
 
-        // Mutation observer is async, so wait one tick.
-        Polymer.Base.async(function() {
-          var input = Polymer.dom(container).querySelector('#i');
-          var inputContent = Polymer.dom(container.root).querySelector('.input-content');
-          var line = Polymer.dom(container.root).querySelector('.underline');
+              input.bindValue = 'foobar';
 
-          input.bindValue = 'foobar';
+              assert.isTrue(container.invalid, 'invalid is true');
+              assert.isTrue(
+                  inputContent.classList.contains('is-invalid'),
+                  'label has invalid styling when input is invalid');
+              assert.isTrue(
+                  line.classList.contains('is-invalid'),
+                  'underline has invalid styling when input is invalid');
+              done();
+            }, 1);
+          });
 
-          assert.isTrue(container.invalid, 'invalid is true');
-          assert.isTrue(inputContent.classList.contains('is-invalid'), 'label has invalid styling when input is invalid');
-          assert.isTrue(line.classList.contains('is-invalid'), 'underline has invalid styling when input is invalid');
-          done();
-        }, 1);
-      });
+      test(
+          'styled when the input is set to an invalid value with auto-validate, with validator',
+          function(done) {
+            var container = Polymer.Element ? fixture('auto-validate-validator-2') :
+                                              fixture('auto-validate-validator-1');
 
-      test('styled when the input is set to an invalid value with auto-validate, with validator', function(done) {
-        var container = Polymer.Element ?
-            fixture('auto-validate-validator-2') :
-            fixture('auto-validate-validator-1');
+            // Mutation observer is async, so wait one tick.
+            Polymer.Base.async(function() {
+              var input = Polymer.dom(container).querySelector('#i');
+              var inputContent =
+                  Polymer.dom(container.root).querySelector('.input-content');
+              var line = Polymer.dom(container.root).querySelector('.underline');
 
-        // Mutation observer is async, so wait one tick.
-        Polymer.Base.async(function() {
-          var input = Polymer.dom(container).querySelector('#i');
-          var inputContent = Polymer.dom(container.root).querySelector('.input-content');
-          var line = Polymer.dom(container.root).querySelector('.underline');
+              input.bindValue = '123123';
 
-          input.bindValue = '123123';
+              assert.isTrue(container.invalid, 'invalid is true');
+              assert.isTrue(
+                  inputContent.classList.contains('is-invalid'),
+                  'label has invalid styling when input is invalid');
+              assert.isTrue(
+                  line.classList.contains('is-invalid'),
+                  'underline has invalid styling when input is invalid');
+              done();
+            }, 1);
+          });
 
-          assert.isTrue(container.invalid, 'invalid is true');
-          assert.isTrue(inputContent.classList.contains('is-invalid'), 'label has invalid styling when input is invalid');
-          assert.isTrue(line.classList.contains('is-invalid'), 'underline has invalid styling when input is invalid');
-          done();
-        }, 1);
-      });
+      test(
+          'styled when the input is set initially to an invalid value with auto-validate, with validator',
+          function(done) {
+            var container = Polymer.Element ?
+                fixture('auto-validate-validator-has-invalid-value-2') :
+                fixture('auto-validate-validator-has-invalid-value-1');
 
-      test('styled when the input is set initially to an invalid value with auto-validate, with validator', function(done) {
-        var container = Polymer.Element ?
-            fixture('auto-validate-validator-has-invalid-value-2') :
-            fixture('auto-validate-validator-has-invalid-value-1');
+            // Mutation observer is async, so wait one tick.
+            Polymer.Base.async(function() {
+              assert.isTrue(container.invalid, 'invalid is true');
+              assert.isTrue(
+                  Polymer.dom(container.root)
+                      .querySelector('.underline')
+                      .classList.contains('is-invalid'),
+                  'underline has is-invalid class');
+              done();
+            }, 1);
+          });
 
-        // Mutation observer is async, so wait one tick.
-        Polymer.Base.async(function() {
-          assert.isTrue(container.invalid, 'invalid is true');
-          assert.isTrue(Polymer.dom(container.root).querySelector('.underline').classList.contains('is-invalid'), 'underline has is-invalid class');
-          done();
-        }, 1);
-      });
+      test(
+          'styled when the input is set to an invalid value with manual validation',
+          function(done) {
+            var container = Polymer.Element ? fixture('manual-validate-numbers-2') :
+                                              fixture('manual-validate-numbers-1');
 
-      test('styled when the input is set to an invalid value with manual validation', function(done) {
-        var container = Polymer.Element ?
-            fixture('manual-validate-numbers-2') :
-            fixture('manual-validate-numbers-1');
+            // Mutation observer is async, so wait one tick.
+            Polymer.Base.async(function() {
+              var input = Polymer.dom(container).querySelector('#i');
+              var inputContent =
+                  Polymer.dom(container.root).querySelector('.input-content');
+              var line = Polymer.dom(container.root).querySelector('.underline');
 
-        // Mutation observer is async, so wait one tick.
-        Polymer.Base.async(function() {
-          var input = Polymer.dom(container).querySelector('#i');
-          var inputContent = Polymer.dom(container.root).querySelector('.input-content');
-          var line = Polymer.dom(container.root).querySelector('.underline');
+              input.bindValue = 'foobar';
+              input.validate();
 
-          input.bindValue = 'foobar';
-          input.validate();
+              assert.isTrue(container.invalid, 'invalid is true');
+              assert.isTrue(
+                  inputContent.classList.contains('is-invalid'),
+                  'label has invalid styling when input is invalid');
+              assert.isTrue(
+                  line.classList.contains('is-invalid'),
+                  'underline has invalid styling when input is invalid');
+              done();
+            }, 1);
+          });
 
-          assert.isTrue(container.invalid, 'invalid is true');
-          assert.isTrue(inputContent.classList.contains('is-invalid'), 'label has invalid styling when input is invalid');
-          assert.isTrue(line.classList.contains('is-invalid'), 'underline has invalid styling when input is invalid');
-          done();
-        }, 1);
-      });
+      test(
+          'styled when the input is manually validated and required',
+          function(done) {
+            var container = Polymer.Element ? fixture('required-validate-2') :
+                                              fixture('required-validate-1');
 
-      test('styled when the input is manually validated and required', function(done) {
-        var container = Polymer.Element ?
-            fixture('required-validate-2') :
-            fixture('required-validate-1');
+            // Mutation observer is async, so wait one tick.
+            Polymer.Base.async(function() {
+              var input = Polymer.dom(container).querySelector('#i');
+              var inputContent =
+                  Polymer.dom(container.root).querySelector('.input-content');
+              var line = Polymer.dom(container.root).querySelector('.underline');
+              assert.isFalse(container.invalid, 'invalid is false');
+              input.validate();
 
-        // Mutation observer is async, so wait one tick.
-        Polymer.Base.async(function() {
-          var input = Polymer.dom(container).querySelector('#i');
-          var inputContent = Polymer.dom(container.root).querySelector('.input-content');
-          var line = Polymer.dom(container.root).querySelector('.underline');
-          assert.isFalse(container.invalid, 'invalid is false');
-          input.validate();
-
-          assert.isTrue(container.invalid, 'invalid is true');
-          assert.isTrue(inputContent.classList.contains('is-invalid'), 'label has invalid styling when input is invalid');
-          assert.isTrue(line.classList.contains('is-invalid'), 'underline has invalid styling when input is invalid');
-          done();
-        }, 1);
-      });
+              assert.isTrue(container.invalid, 'invalid is true');
+              assert.isTrue(
+                  inputContent.classList.contains('is-invalid'),
+                  'label has invalid styling when input is invalid');
+              assert.isTrue(
+                  line.classList.contains('is-invalid'),
+                  'underline has invalid styling when input is invalid');
+              done();
+            }, 1);
+          });
     });
-
   </script>
 
 </body>

--- a/test/paper-input-error.html
+++ b/test/paper-input-error.html
@@ -55,32 +55,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <script>
-
     suite('basic', function() {
-
       test('error message only appears when input is invalid', function(done) {
-        var container = Polymer.Element ?
-            fixture('auto-validate-numbers-2') :
-            fixture('auto-validate-numbers-1');
+        var container = Polymer.Element ? fixture('auto-validate-numbers-2') :
+                                          fixture('auto-validate-numbers-1');
         var input = Polymer.dom(container).querySelector('#i');
         var error = Polymer.dom(container).querySelector('#e');
 
         // Need to wait a tick to stamp the error message.
         Polymer.Base.async(function() {
-          assert.equal(getComputedStyle(error).visibility, 'hidden', 'error is visibility:hidden');
+          assert.equal(
+              getComputedStyle(error).visibility,
+              'hidden',
+              'error is visibility:hidden');
           input.bindValue = 'foobar';
-          assert.equal(getComputedStyle(error).visibility, 'visible', 'error is visibility:visible');
+          assert.equal(
+              getComputedStyle(error).visibility,
+              'visible',
+              'error is visibility:visible');
           done();
         }, 1);
       });
 
       test('error message add on is registered', function() {
         var container = document.getElementById('container');
-        assert.isTrue(container._addons && container._addons.length === 1, 'add on is registered');
+        assert.isTrue(
+            container._addons && container._addons.length === 1,
+            'add on is registered');
       });
-
     });
-
   </script>
 
 </body>

--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -128,10 +128,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return paperInput.inputElement;
     }
     function getNativeInput(paperInput) {
-      return Polymer.Element ? paperInput.inputElement.inputElement : paperInput.inputElement;
+      return Polymer.Element ? paperInput.inputElement.inputElement :
+                               paperInput.inputElement;
     }
     function getFloatingLabel(paperInput) {
-      return Polymer.dom(Polymer.dom(paperInput.root).querySelector('paper-input-container').root)
+      return Polymer
+          .dom(Polymer.dom(paperInput.root)
+                   .querySelector('paper-input-container')
+                   .root)
           .querySelector('.label-is-floating');
     }
     function getErrorDiv(paperInput) {
@@ -156,8 +160,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Mutation observer is async, so wait one tick.
         Polymer.Base.async(function() {
           input.value = 'foobar';
-          assert.equal(getIronInput(input).value, input.value, 'iron-input value equals input.value');
-          assert.equal(getNativeInput(input).value, input.value, 'iron-getNativeInput(input) value equals input.value');
+          assert.equal(
+              getIronInput(input).value,
+              input.value,
+              'iron-input value equals input.value');
+          assert.equal(
+              getNativeInput(input).value,
+              input.value,
+              'iron-getNativeInput(input) value equals input.value');
           done();
         }, 1);
       });
@@ -167,7 +177,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // Mutation observer is async, so wait one tick.
         Polymer.Base.async(function() {
-          assert.equal(getNativeInput(input).placeholder, input.placeholder, 'inputElement.placeholder equals input.placeholder');
+          assert.equal(
+              getNativeInput(input).placeholder,
+              input.placeholder,
+              'inputElement.placeholder equals input.placeholder');
           assert.equal(input.noLabelFloat, false);
           assert.ok(getFloatingLabel(input));
           done();
@@ -182,7 +195,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // Browsers that don't support special <input> types like `date` fallback
           // to `text`, so make sure to only test if type is still preserved after
           // the element is attached.
-          if (getNativeInput(input).type === "date") {
+          if (getNativeInput(input).type === 'date') {
             assert.equal(input.alwaysFloatLabel, true);
             assert.ok(getFloatingLabel(input));
           }
@@ -190,24 +203,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }, 1);
       });
 
-      test('setting the value to the empty string unfloats the label', function(done) {
-        var input = fixture('basic');
+      test(
+          'setting the value to the empty string unfloats the label',
+          function(done) {
+            var input = fixture('basic');
 
-        // Mutation observer is async, so wait one tick.
-        Polymer.Base.async(function() {
-          // Initially the value isn't floating.
-          assert.equal(getFloatingLabel(input), null);
+            // Mutation observer is async, so wait one tick.
+            Polymer.Base.async(function() {
+              // Initially the value isn't floating.
+              assert.equal(getFloatingLabel(input), null);
 
-          // The label is floating if it has a value.
-          input.value = 'foobar';
-          assert.ok(getFloatingLabel(input));
+              // The label is floating if it has a value.
+              input.value = 'foobar';
+              assert.ok(getFloatingLabel(input));
 
-          // The label isn't floating if it gets reset.
-          input.value = '';
-          assert.equal(getFloatingLabel(input), null);
-          done();
-        }, 1);
-      });
+              // The label isn't floating if it gets reset.
+              input.value = '';
+              assert.equal(getFloatingLabel(input), null);
+              done();
+            }, 1);
+          });
 
       test('setting the value to null unfloats the label', function(done) {
         var input = fixture('basic');
@@ -249,9 +264,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('always-float-label attribute works without placeholder', function() {
         var input = fixture('always-float-label');
-        var container = Polymer.dom(input.root).querySelector('paper-input-container');
-        var inputContent = Polymer.dom(container.root).querySelector('.input-content');
-        assert.isTrue(inputContent.classList.contains('label-is-floating'), 'label is floating');
+        var container =
+            Polymer.dom(input.root).querySelector('paper-input-container');
+        var inputContent =
+            Polymer.dom(container.root).querySelector('.input-content');
+        assert.isTrue(
+            inputContent.classList.contains('label-is-floating'),
+            'label is floating');
       });
 
       test('label does not receive pointer events', function() {
@@ -263,7 +282,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('error message is displayed', function() {
         var input = fixture('error');
         var errorDiv = getErrorDiv(input);
-        assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+        assert.notEqual(
+            getComputedStyle(error).visibility,
+            'hidden',
+            'error is not visibility:hidden');
       });
 
       test('character counter is displayed', function(done) {
@@ -273,7 +295,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Polymer.Base.async(function() {
           var counter = getCharCounterDiv(input);
           assert.ok(counter, 'paper-input-char-counter exists');
-          assert.equal(counter._charCounterStr, input.value.length, 'character counter shows the value length');
+          assert.equal(
+              counter._charCounterStr,
+              input.value.length,
+              'character counter shows the value length');
           done();
         }, 1);
       });
@@ -285,7 +310,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Polymer.Base.async(function() {
           var counter = getCharCounterDiv(input)
           assert.ok(counter, 'paper-input-char-counter exists');
-          assert.equal(counter._charCounterStr, input.value.toString().length, 'character counter shows the value length');
+          assert.equal(
+              counter._charCounterStr,
+              input.value.toString().length,
+              'character counter shows the value length');
           done();
         }, 1);
       });
@@ -324,7 +352,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           }, 50);
           input.autofocus = true;
-
         }, 1);
       });
     });
@@ -352,11 +379,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // When you focus a paper-input, this is what happens:
       // paper-input gets focused -> it focuses its nested <input>
-      // In shadow DOM, the nested <input>'s focus event stays inside the shadow root.
-      // In shady DOM, this is a different event (it blurs the paper-input and fires
-      // another focus event for the 'input (which we retarget).
-      // This means that in Shady DOM, you get *two* focus events (and a blur)
-      // every time a paper-input is focused.
+      // In shadow DOM, the nested <input>'s focus event stays inside the shadow
+      // root. In shady DOM, this is a different event (it blurs the paper-input and
+      // fires another focus event for the 'input (which we retarget). This means
+      // that in Shady DOM, you get *two* focus events (and a blur) every time a
+      // paper-input is focused.
       test('focus events fired on host element', function(done) {
         // Mutation observer is async, so wait one tick.
         Polymer.Base.async(function() {
@@ -368,15 +395,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }, 1);
       });
 
-      test('focus events fired on host element if nested element is focused', function(done) {
-        // Mutation observer is async, so wait one tick.
-        Polymer.Base.async(function() {
-          getNativeInput(input).focus();
-          assert(input.focused, 'input is focused');
-          assert(inputFocusSpy.callCount > 0, 'focus event fired');
-          done();
-        }, 1);
-      });
+      test(
+          'focus events fired on host element if nested element is focused',
+          function(done) {
+            // Mutation observer is async, so wait one tick.
+            Polymer.Base.async(function() {
+              getNativeInput(input).focus();
+              assert(input.focused, 'input is focused');
+              assert(inputFocusSpy.callCount > 0, 'focus event fired');
+              done();
+            }, 1);
+          });
 
       test('blur events fired on host element', function(done) {
         // Mutation observer is async, so wait one tick.
@@ -396,47 +425,54 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }, 1);
       });
 
-      test('blur events fired on host element nested element is blurred', function(done) {
-        // Mutation observer is async, so wait one tick.
-        Polymer.Base.async(function() {
-          input.focus();
-          assert(inputFocusSpy.callCount > 0, 'focus event fired');
+      test(
+          'blur events fired on host element nested element is blurred',
+          function(done) {
+            // Mutation observer is async, so wait one tick.
+            Polymer.Base.async(function() {
+              input.focus();
+              assert(inputFocusSpy.callCount > 0, 'focus event fired');
 
-          var blursBecauseOfFocus = blurFocusSpy.callCount;
-          getNativeInput(input).blur();
-          assert(blurFocusSpy.callCount > blursBecauseOfFocus, 'blur event fired');
-          done();
-        }, 1)
-      });
+              var blursBecauseOfFocus = blurFocusSpy.callCount;
+              getNativeInput(input).blur();
+              assert(
+                  blurFocusSpy.callCount > blursBecauseOfFocus, 'blur event fired');
+              done();
+            }, 1)
+          });
 
-      test('focusing then bluring sets the focused attribute correctly', function(done) {
-        // Mutation observer is async, so wait one tick.
-        Polymer.Base.async(function() {
-          input.focus();
-          assert(input.focused, 'input is focused');
-          getNativeInput(input).blur();
-          assert(!input.focused, 'input is blurred');
-          getNativeInput(input).focus();
-          assert(input.focused, 'input is focused');
-          getNativeInput(input).blur();
-          assert(!input.focused, 'input is blurred');
-          done();
-        }, 1);
-      });
+      test(
+          'focusing then bluring sets the focused attribute correctly',
+          function(done) {
+            // Mutation observer is async, so wait one tick.
+            Polymer.Base.async(function() {
+              input.focus();
+              assert(input.focused, 'input is focused');
+              getNativeInput(input).blur();
+              assert(!input.focused, 'input is blurred');
+              getNativeInput(input).focus();
+              assert(input.focused, 'input is focused');
+              getNativeInput(input).blur();
+              assert(!input.focused, 'input is blurred');
+              done();
+            }, 1);
+          });
 
-      test('focusing then bluring with shift-tab removes the focused attribute correctly', function(done) {
-        // Mutation observer is async, so wait one tick.
-        Polymer.Base.async(function() {
-          input.focus();
-          assert(input.focused, 'input is focused');
+      test(
+          'focusing then bluring with shift-tab removes the focused attribute correctly',
+          function(done) {
+            // Mutation observer is async, so wait one tick.
+            Polymer.Base.async(function() {
+              input.focus();
+              assert(input.focused, 'input is focused');
 
-          // Fake a shift-tab induced blur by forcing the flag.
-          input._shiftTabPressed = true;
-          getNativeInput(input).blur();
-          assert(!input.focused, 'input is blurred');
-          done();
-        }, 1);
-      });
+              // Fake a shift-tab induced blur by forcing the flag.
+              input._shiftTabPressed = true;
+              getNativeInput(input).blur();
+              assert(!input.focused, 'input is blurred');
+              done();
+            }, 1);
+          });
     });
 
     suite('focused styling (integration test)', function() {
@@ -444,13 +480,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var input = fixture('basic');
         // Mutation observer is async, so wait one tick.
         Polymer.Base.async(function() {
-          var container = Polymer.dom(input.root).querySelector('paper-input-container');
+          var container =
+              Polymer.dom(input.root).querySelector('paper-input-container');
           var line = Polymer.dom(container.root).querySelector('.underline');
-          assert.isFalse(line.classList.contains('is-highlighted'), 'line is not highlighted when input is not focused');
+          assert.isFalse(
+              line.classList.contains('is-highlighted'),
+              'line is not highlighted when input is not focused');
 
           input.focus();
           requestAnimationFrame(function() {
-            assert.isTrue(line.classList.contains('is-highlighted'), 'line is highlighted when input is focused');
+            assert.isTrue(
+                line.classList.contains('is-highlighted'),
+                'line is highlighted when input is focused');
             done();
           });
         }, 1);
@@ -458,7 +499,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('validation', function() {
-
       test('invalid attribute updated after calling validate()', function(done) {
         var input = fixture('required-no-auto-validate');
 
@@ -470,7 +510,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           Polymer.Base.async(function() {
             var error = getErrorDiv(input);
             assert.ok(error, 'paper-input-error exists');
-            assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+            assert.notEqual(
+                getComputedStyle(error).visibility,
+                'hidden',
+                'error is not visibility:hidden');
             assert.isTrue(input.invalid, 'invalid is true');
             done();
           }, 1);
@@ -479,29 +522,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('a11y', function() {
-      test('has aria-labelledby, which is monotonically increasing', function(done) {
-        var inputs = fixture('multiple-inputs');
+      test(
+          'has aria-labelledby, which is monotonically increasing', function(done) {
+            var inputs = fixture('multiple-inputs');
 
-        // Mutation observer is async, so wait one tick.
-        Polymer.Base.async(function() {
-          // Find the first index of the input in this fixture. Since the label
-          // ids monotonically increase every time a new input is created, and
-          // this fixture isn't the first one in the document, we're going to start
-          // at an ID > 1.
-          var firstLabel = Polymer.dom(inputs[0].root).querySelector('label').id;
-          var index = parseInt(firstLabel.substr(firstLabel.lastIndexOf('-') + 1));
+            // Mutation observer is async, so wait one tick.
+            Polymer.Base.async(function() {
+              // Find the first index of the input in this fixture. Since the label
+              // ids monotonically increase every time a new input is created, and
+              // this fixture isn't the first one in the document, we're going to
+              // start at an ID > 1.
+              var firstLabel =
+                  Polymer.dom(inputs[0].root).querySelector('label').id;
+              var index =
+                  parseInt(firstLabel.substr(firstLabel.lastIndexOf('-') + 1));
 
-          for (var i = 0; i < inputs.length; i++ ) {
-            var input = getNativeInput(inputs[i]);
-            var label = Polymer.dom(inputs[i].root).querySelector('label').id;
+              for (var i = 0; i < inputs.length; i++) {
+                var input = getNativeInput(inputs[i]);
+                var label = Polymer.dom(inputs[i].root).querySelector('label').id;
 
-            assert.isTrue(input.hasAttribute('aria-labelledby'));
-            assert.equal(label, 'paper-input-label-' + (index++));
-            assert.equal(input.getAttribute('aria-labelledby'), label);
-          }
-          done();
-        }, 1)
-      });
+                assert.isTrue(input.hasAttribute('aria-labelledby'));
+                assert.equal(label, 'paper-input-label-' + (index++));
+                assert.equal(input.getAttribute('aria-labelledby'), label);
+              }
+              done();
+            }, 1)
+          });
 
       test('has aria-describedby for error message', function(done) {
         var input = fixture('required');
@@ -509,7 +555,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Need to wait a tick to stamp the error message.
         Polymer.Base.async(function() {
           assert.isTrue(getNativeInput(input).hasAttribute('aria-describedby'));
-          assert.equal(getNativeInput(input).getAttribute('aria-describedby'), getErrorDiv(input).id, 'aria-describedby points to the error message');
+          assert.equal(
+              getNativeInput(input).getAttribute('aria-describedby'),
+              getErrorDiv(input).id,
+              'aria-describedby points to the error message');
           done();
         }, 1);
       });
@@ -520,7 +569,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Need to wait a tick to stamp the char-counter.
         Polymer.Base.async(function() {
           assert.isTrue(getNativeInput(input).hasAttribute('aria-describedby'));
-          assert.equal(getNativeInput(input).getAttribute('aria-describedby'), getCharCounterDiv(input).id, 'aria-describedby points to the character counter');
+          assert.equal(
+              getNativeInput(input).getAttribute('aria-describedby'),
+              getCharCounterDiv(input).id,
+              'aria-describedby points to the character counter');
           done();
         }, 1);
       });
@@ -531,11 +583,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Need to wait a tick to stamp the char-counter and error message.
         Polymer.Base.async(function() {
           assert.isTrue(getNativeInput(input).hasAttribute('aria-describedby'));
-          var ariaDescribedBy = getNativeInput(input).getAttribute('aria-describedby');
+          var ariaDescribedBy =
+              getNativeInput(input).getAttribute('aria-describedby');
 
-          assert.notEqual(ariaDescribedBy.indexOf(getErrorDiv(input).id, -1,
+          assert.notEqual(ariaDescribedBy.indexOf(
+              getErrorDiv(input).id,
+              -1,
               'aria-describedby points to the error message'));
-          assert.notEqual(ariaDescribedBy.indexOf(getCharCounterDiv(input).id, -1,
+          assert.notEqual(ariaDescribedBy.indexOf(
+              getCharCounterDiv(input).id,
+              -1,
               'aria-describedby points to the character counter'));
           done();
         }, 1);
@@ -551,21 +608,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Mutation observer is async, so wait one tick.
         Polymer.Base.async(function() {
           input.focus();
-          assert.equal(input.shadowRoot ? input.shadowRoot.activeElement :
-                  document.activeElement, input._focusableElement);
+          assert.equal(
+              input.shadowRoot ? input.shadowRoot.activeElement :
+                                 document.activeElement,
+              input._focusableElement);
           done();
         }, 1);
       });
     });
 
     suite('a11ySuite', function() {
-      // Note(notwaldorf): In the 1.x variant we get this false negative on each input.
-      // Error: AX_ARIA_04 (ARIA state and property values must be valid) failed on the following element:
-      // #input
-      // See https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_04 for more information.
-      // As far as I can see this isn't true; I ran the Lighthouse tests
-      // separately, and they were fine. Disabling these for 1.x, since they
-      // just add noise to Travis, and we don't know how to fix them.
+      // Note(notwaldorf): In the 1.x variant we get this false negative on each
+      // input. Error: AX_ARIA_04 (ARIA state and property values must be valid)
+      // failed on the following element: #input See
+      // https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_04
+      // for more information. As far as I can see this isn't true; I ran the
+      // Lighthouse tests separately, and they were fine. Disabling these for 1.x,
+      // since they just add noise to Travis, and we don't know how to fix them.
       test('run suite only for Polymer 2.x', function() {
         if (!Polymer.Element) {
           this.skip();

--- a/test/paper-textarea.html
+++ b/test/paper-textarea.html
@@ -64,12 +64,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <script>
-
     suite('basic', function() {
       test('setting value sets the input value', function() {
         var input = fixture('basic');
         input.value = 'foobar';
-        assert.equal(input.inputElement.bindValue, input.value, 'inputElement value equals input.value');
+        assert.equal(
+            input.inputElement.bindValue,
+            input.value,
+            'inputElement value equals input.value');
       });
 
       test('empty required input shows error', function(done) {
@@ -79,14 +81,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Polymer.Base.async(function() {
           var error = Polymer.dom(input.root).querySelector('paper-input-error');
           assert.ok(error, 'paper-input-error exists');
-          assert.notEqual(getComputedStyle(error).display, 'none', 'error is not display:none');
+          assert.notEqual(
+              getComputedStyle(error).display, 'none', 'error is not display:none');
           done();
         }, 1);
       });
 
       test('caret position is preserved', function() {
         var input = fixture('basic');
-        var ironTextarea = Polymer.dom(input.root).querySelector('iron-autogrow-textarea');
+        var ironTextarea =
+            Polymer.dom(input.root).querySelector('iron-autogrow-textarea');
         input.value = 'nananana';
         ironTextarea.selectionStart = 2;
         ironTextarea.selectionEnd = 2;
@@ -115,18 +119,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         for (var attr in attrs) {
           var inputAttr = input.inputElement.getAttribute(attr);
           if (typeof attrs[attr] === 'boolean') {
-            assert.equal(inputAttr !== null, attrs[attr], 'attribute "' + attr + '" is equal to property (' + attrs[attr] + ', ' + inputAttr !== null + ')');
+            assert.equal(
+                inputAttr !== null,
+                attrs[attr],
+                'attribute "' + attr + '" is equal to property (' + attrs[attr] +
+                        ', ' + inputAttr !==
+                    null + ')');
           } else {
-            assert.equal(inputAttr, attrs[attr], 'attribute "' + attr + '" is equal to property (' + attrs[attr] + ', ' + inputAttr + ')');
+            assert.equal(
+                inputAttr,
+                attrs[attr],
+                'attribute "' + attr + '" is equal to property (' + attrs[attr] +
+                    ', ' + inputAttr + ')');
           }
         }
       });
 
       test('always-float-label attribute works', function() {
         var input = fixture('always-float-label');
-        var container = Polymer.dom(input.root).querySelector('paper-input-container');
-        var inputContent = Polymer.dom(container.root).querySelector('.input-content');
-        assert.isTrue(inputContent.classList.contains('label-is-floating'), 'label is floating');
+        var container =
+            Polymer.dom(input.root).querySelector('paper-input-container');
+        var inputContent =
+            Polymer.dom(container.root).querySelector('.input-content');
+        assert.isTrue(
+            inputContent.classList.contains('label-is-floating'),
+            'label is floating');
       });
 
       test('label does not receive pointer events', function() {
@@ -137,10 +154,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('no extra space between input and underline', function() {
         var input = fixture('label');
-        var container = Polymer.dom(input.root).querySelector('paper-input-container');
-        var inputContent = Polymer.dom(container.root).querySelector('.input-content');
-        var ironTextarea = Polymer.dom(input.root).querySelector('iron-autogrow-textarea');
-        assert.equal(inputContent.clientHeight, ironTextarea.clientHeight, 'container and textarea are same height');
+        var container =
+            Polymer.dom(input.root).querySelector('paper-input-container');
+        var inputContent =
+            Polymer.dom(container.root).querySelector('.input-content');
+        var ironTextarea =
+            Polymer.dom(input.root).querySelector('iron-autogrow-textarea');
+        assert.equal(
+            inputContent.clientHeight,
+            ironTextarea.clientHeight,
+            'container and textarea are same height');
       });
     });
 
@@ -188,12 +211,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         MockInteractions.focus(input);
       });
 
-      test('focus events fired on host element if nested element is focused', function() {
-        input.addEventListener('focus', function() {
-          assert(input.focused, 'input is focused');
-        });
-        MockInteractions.focus(input.inputElement.textarea);
-      });
+      test(
+          'focus events fired on host element if nested element is focused',
+          function() {
+            input.addEventListener('focus', function() {
+              assert(input.focused, 'input is focused');
+            });
+            MockInteractions.focus(input.inputElement.textarea);
+          });
 
       // TODO(notwaldorf): Re-enable this test when
       // https://github.com/webcomponents/shadydom/issues/126 is fixed.
@@ -207,7 +232,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // TODO(notwaldorf): Re-enable this test when
       // https://github.com/webcomponents/shadydom/issues/126 is fixed.
-      // test('blur events fired on host element nested element is blurred', function() {
+      // test('blur events fired on host element nested element is blurred',
+      // function() {
       //   MockInteractions.focus(input);
       //   input.addEventListener('blur', function(event) {
       //     assert(!input.focused, 'input is blurred');
@@ -217,7 +243,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // TODO(notwaldorf): Re-enable this test when
       // https://github.com/webcomponents/shadydom/issues/126 is fixed.
-      // test('focusing then bluring sets the focused attribute correctly', function() {
+      // test('focusing then bluring sets the focused attribute correctly',
+      // function() {
       //   MockInteractions.focus(input);
       //   assert(input.focused, 'input is focused');
       //   MockInteractions.blur(input);
@@ -230,11 +257,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('a11y', function() {
-
       test('has aria-labelledby', function() {
         var input = fixture('label');
         assert.isTrue(input.inputElement.textarea.hasAttribute('aria-labelledby'))
-        assert.equal(input.inputElement.textarea.getAttribute('aria-labelledby'), Polymer.dom(input.root).querySelector('label').id, 'aria-labelledby points to the label');
+        assert.equal(
+            input.inputElement.textarea.getAttribute('aria-labelledby'),
+            Polymer.dom(input.root).querySelector('label').id,
+            'aria-labelledby points to the label');
       });
 
       test('has aria-describedby for error message', function(done) {
@@ -242,8 +271,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // Need to wait a tick to stamp the error message.
         Polymer.Base.async(function() {
-          assert.isTrue(input.inputElement.textarea.hasAttribute('aria-describedby'));
-          assert.equal(input.inputElement.textarea.getAttribute('aria-describedby'), Polymer.dom(input.root).querySelector('paper-input-error').id, 'aria-describedby points to the error message');
+          assert.isTrue(
+              input.inputElement.textarea.hasAttribute('aria-describedby'));
+          assert.equal(
+              input.inputElement.textarea.getAttribute('aria-describedby'),
+              Polymer.dom(input.root).querySelector('paper-input-error').id,
+              'aria-describedby points to the error message');
           done();
         }, 1);
       });
@@ -253,8 +286,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // Need to wait a tick to stamp the char-counter.
         Polymer.Base.async(function() {
-          assert.isTrue(input.inputElement.textarea.hasAttribute('aria-describedby'));
-          assert.equal(input.inputElement.textarea.getAttribute('aria-describedby'), Polymer.dom(input.root).querySelector('paper-input-char-counter').id, 'aria-describedby points to the character counter');
+          assert.isTrue(
+              input.inputElement.textarea.hasAttribute('aria-describedby'));
+          assert.equal(
+              input.inputElement.textarea.getAttribute('aria-describedby'),
+              Polymer.dom(input.root).querySelector('paper-input-char-counter').id,
+              'aria-describedby points to the character counter');
           done();
         }, 1);
       });
@@ -264,13 +301,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // Need to wait a tick to stamp the char-counter and error message.
         Polymer.Base.async(function() {
-          assert.isTrue(input.inputElement.textarea.hasAttribute('aria-describedby'));
-          var ariaDescribedBy = input.inputElement.textarea.getAttribute('aria-describedby');
+          assert.isTrue(
+              input.inputElement.textarea.hasAttribute('aria-describedby'));
+          var ariaDescribedBy =
+              input.inputElement.textarea.getAttribute('aria-describedby');
 
-          assert.notEqual(ariaDescribedBy.indexOf(Polymer.dom(input.root).querySelector('paper-input-error').id, -1,
-            'aria-describedby points to the error message'));
-          assert.notEqual(ariaDescribedBy.indexOf(Polymer.dom(input.root).querySelector('paper-input-char-counter').id, -1,
-            'aria-describedby points to the character counter'));
+          assert.notEqual(ariaDescribedBy.indexOf(
+              Polymer.dom(input.root).querySelector('paper-input-error').id,
+              -1,
+              'aria-describedby points to the error message'));
+          assert.notEqual(ariaDescribedBy.indexOf(
+              Polymer.dom(input.root).querySelector('paper-input-char-counter').id,
+              -1,
+              'aria-describedby points to the character counter'));
           done();
         }, 1);
       });


### PR DESCRIPTION
Runs the experimental autoformatter [webmat](https://github.com/PolymerLabs/webmat) which runs clang-format on js files and makes it so that it can run on HTML files. Please look through this PR with `?w=1` in the diff to make sure that no logic was changed.

What has changed?
You can run the formatter on the whole project by running `npm run format` and ex/include files from the formatter, and enter your custom clang-format config in a formatconfig.json see webmat readme for more!