### PR TITLE
Fixes Auto-Validation fires directly for required without any user interaction

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -556,7 +556,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       // validation, just this once.
       if (this.__isFirstValueUpdate) {
         this.__isFirstValueUpdate = false;
-        if (input.value === undefined) {
+        if (input.value === undefined || input.value === '') {
           return;
         }
       }


### PR DESCRIPTION
This resolves issues [134](https://github.com/PolymerElements/iron-input/issues/134) and [655](https://github.com/PolymerElements/paper-input/issues/655) introduced from [PR 130](https://github.com/PolymerElements/iron-input/pull/130).

Allowing '' here (along with undefined) should not create any issues because it is only checking once on startup.  The alternative is to revert PR 130 but I am not sure why setting a default was needed.

