### PR TITLE
fix paper-textarea types

### DIFF
--- a/paper-textarea.d.ts
+++ b/paper-textarea.d.ts
@@ -33,6 +33,7 @@
  * style this element.
  */
 interface PaperTextareaElement extends Polymer.Element, Polymer.PaperInputBehavior, Polymer.IronFormElementBehavior {
+  value: string|null|undefined;
   _ariaDescribedBy: string|null|undefined;
   _ariaLabelledBy: string|null|undefined;
   readonly _focusableElement: any;
@@ -40,13 +41,13 @@ interface PaperTextareaElement extends Polymer.Element, Polymer.PaperInputBehavi
   /**
    * The initial number of rows.
    */
-  rows: number|null|undefined;
+  rows: number;
 
   /**
    * The maximum number of rows this element can grow to until it
    * scrolls. 0 means no maximum.
    */
-  maxRows: number|null|undefined;
+  maxRows: number;
   selectionStart: number;
   selectionEnd: number;
   _ariaLabelledByChanged(ariaLabelledBy: any): void;

--- a/paper-textarea.html
+++ b/paper-textarea.html
@@ -111,11 +111,16 @@ style this element.
         type: String,
       },
 
+      value: {
+        // Required for the correct TypeScript type-generation
+        type: String,
+      },
+
       /**
        * The initial number of rows.
        *
        * @attribute rows
-       * @type number
+       * @type {number}
        * @default 1
        */
       rows: {
@@ -128,7 +133,7 @@ style this element.
        * scrolls. 0 means no maximum.
        *
        * @attribute maxRows
-       * @type number
+       * @type {number}
        * @default 0
        */
       maxRows: {


### PR DESCRIPTION
fix types on paper-textarea. This is due to the closure fix in PolymerElements/iron-form-element-behavior#47