### PR TITLE
Allow styling of placeholder on paper-input #676

### DIFF
--- a/paper-input.js
+++ b/paper-input.js
@@ -155,7 +155,7 @@ Polymer({
       }
 
       input:-ms-input-placeholder {
-        color: var(--paper-input-container-color, var(--secondary-text-color));
+        color: var(--paper-input-container-input-placeholder-color, var(--paper-input-container-color, var(--secondary-text-color)));
       }
 
       label {

--- a/paper-input.js
+++ b/paper-input.js
@@ -71,6 +71,7 @@ The following custom properties and mixins are available for styling:
 Custom property | Description | Default
 ----------------|-------------|----------
 `--paper-input-container-ms-clear` | Mixin applied to the Internet Explorer reveal button (the eyeball) | {}
+`--paper-input-container-input-placeholder-color` | The foreground color of the placeholder | `--paper-input-container-color`, `--secondary-text-color`
 
 @group Paper Elements
 @element paper-input

--- a/paper-input.js
+++ b/paper-input.js
@@ -134,15 +134,15 @@ Polymer({
       }
 
       input::-webkit-input-placeholder {
-        color: var(--paper-input-container-color, var(--secondary-text-color));
+        color: var(--paper-input-container-input-placeholder-color, var(--paper-input-container-color, var(--secondary-text-color)));
       }
 
       input:-moz-placeholder {
-        color: var(--paper-input-container-color, var(--secondary-text-color));
+        color: var(--paper-input-container-input-placeholder-color, var(--paper-input-container-color, var(--secondary-text-color)));
       }
 
       input::-moz-placeholder {
-        color: var(--paper-input-container-color, var(--secondary-text-color));
+        color: var(--paper-input-container-input-placeholder-color, var(--paper-input-container-color, var(--secondary-text-color)));
       }
 
       input::-ms-clear {


### PR DESCRIPTION
Fixes #676 

This fixes #676 by allowing developers to deliberately change just the color of the input's placeholder using `--paper-input-container-input-placeholder-color`.