### PR TITLE
autocapitalize should not have a nullable type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ addons:
   firefox: latest
   chrome: stable
 script:
-  - xvfb-run polymer test --module-resolution=node --npm
+  - xvfb-run polymer test --module-resolution=node --npm --local chrome
+  - xvfb-run polymer test --module-resolution=node --npm --local firefox
   - >-
     if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test
     --module-resolution=node --npm -s 'default'; fi

--- a/paper-input-behavior.js
+++ b/paper-input-behavior.js
@@ -253,6 +253,8 @@ export const PaperInputBehaviorImpl = {
      * If you're using PaperInputBehavior to implement your own paper-input-like
      * element, bind this to the `<input is="iron-input">`'s `autocapitalize`
      * property.
+     *
+     * @type {string}
      */
     autocapitalize: {type: String, value: 'none'},
 


### PR DESCRIPTION
For compatibility with the type of HTMLElement#autocapitalize which, in TypeScript at least, is just `string` not `string|null|undefined`

Downstreamed as cl/221176969