### PR TITLE
Skip a 'blur' event test if the browser has a bug that would prevent it from working.

### DIFF
--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -419,12 +419,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // If `document.activeElement` hasn't changed, then the bug exists
           // and we shouldn't run this test.
           const shouldSkip = document.activeElement === div;
-          document.body.removeChild(div);
           if (shouldSkip) {
+            document.body.removeChild(div);
             this.skip();
             return;
           }
         }
+        document.body.removeChild(div);
 
         // Mutation observer is async, so wait one tick.
         Base.async(function() {

--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -407,22 +407,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Firefox's Shadow DOM implementation seems to have a bug where
         // calling `blur` on an element with a shadow root containing the true
         // focused node doesn't blur the node.
-        const shouldSkip = (() => {
-          const div = document.createElement('div');
-          const input = document.createElement('input');
-          div.attachShadow({mode: 'open'}).appendChild(input);
-          document.body.appendChild(div);
-          input.focus();
-          assert(document.activeElement === div);
+        const div = document.createElement('div');
+        const input = document.createElement('input');
+        div.attachShadow({mode: 'open'}).appendChild(input);
+        document.body.appendChild(div);
+        input.focus();
+        // If we're in native Shadow DOM, `document.activeElement` will be the
+        // div because we just focused an element in its shadow root.
+        if (document.activeElement === div) {
           div.blur();
           // If `document.activeElement` hasn't changed, then the bug exists
           // and we shouldn't run this test.
-          return document.activeElement === div;
-        })();
-
-        if (shouldSkip) {
-          this.skip();
-          return;
+          const shouldSkip = document.activeElement === div;
+          document.body.removeChild(div);
+          if (shouldSkip) {
+            this.skip();
+            return;
+          }
         }
 
         // Mutation observer is async, so wait one tick.

--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -408,10 +408,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // calling `blur` on an element with a shadow root containing the true
         // focused node doesn't blur the node.
         const div = document.createElement('div');
-        const input = document.createElement('input');
-        div.attachShadow({mode: 'open'}).appendChild(input);
+        const shadowInput = document.createElement('input');
+        div.attachShadow({mode: 'open'}).appendChild(shadowInput);
         document.body.appendChild(div);
-        input.focus();
+        shadowInput.focus();
         // If we're in native Shadow DOM, `document.activeElement` will be the
         // div because we just focused an element in its shadow root.
         if (document.activeElement === div) {

--- a/test/paper-input.html
+++ b/test/paper-input.html
@@ -404,6 +404,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
 
       test('blur events fired on host element', function(done) {
+        // Firefox's Shadow DOM implementation seems to have a bug where
+        // calling `blur` on an element with a shadow root containing the true
+        // focused node doesn't blur the node.
+        const shouldSkip = (() => {
+          const div = document.createElement('div');
+          const input = document.createElement('input');
+          div.attachShadow({mode: 'open'}).appendChild(input);
+          document.body.appendChild(div);
+          input.focus();
+          assert(document.activeElement === div);
+          div.blur();
+          // If `document.activeElement` hasn't changed, then the bug exists
+          // and we shouldn't run this test.
+          return document.activeElement === div;
+        })();
+
+        if (shouldSkip) {
+          this.skip();
+          return;
+        }
+
         // Mutation observer is async, so wait one tick.
         Base.async(function() {
           input.focus();


### PR DESCRIPTION
Firefox seems to have a bug where calling `blur` on an element with a ShadowRoot containing a focused element doesn't do anything. This checks for the bug and skips the test if present.