### PR TITLE
make sure event.target is the real addons target

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -521,7 +521,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       if (!this._addons) {
         this._addons = [];
       }
-      var target = event.target;
+      var target = event.composedPath ? event.composedPath()[0] : event.target;
       if (this._addons.indexOf(target) === -1) {
         this._addons.push(target);
         if (this.isAttached) {


### PR DESCRIPTION
We want the real addons target to be added as addons. 

Due to shadowDom event retargeting, `event.target` is is not the addon anymore in some advanced templating scenario. As a result, `updateAddons` call a not-existing `update` method, creating an error. 

This PR makes sure we add the initial event target.

This PR is against the 2.x branch (which I use), but the observed error is expected to happen under 3.x as well.