### PR TITLE
Prevent error messages from being read by screen readers when the input is not in an error state.

### DIFF
--- a/paper-input-error.js
+++ b/paper-input-error.js
@@ -55,10 +55,29 @@ Polymer({
 
       :host([invalid]) {
         visibility: visible;
-      };
+      }
+
+      #a11yWrapper {
+        visibility: hidden;
+      }
+
+      :host([invalid]) #a11yWrapper {
+        visibility: visible;
+      }
     </style>
 
-    <slot></slot>
+    <!--
+    If the paper-input-error element is directly referenced by an
+    \`aria-describedby\` attribute, such as when used as a paper-input add-on,
+    then applying \`visibility: hidden;\` to the paper-input-error element itself
+    does not hide the error.
+
+    For more information, see:
+    https://www.w3.org/TR/accname-1.1/#mapping_additional_nd_description
+    -->
+    <div id="a11yWrapper">
+      <slot></slot>
+    </div>
 `,
 
   is: 'paper-input-error',


### PR DESCRIPTION
Hide the content of paper-input-error elements with `invalid === false` using `visibility: hidden;` on an internal wrapper element so that it isn't read by screen readers even if the paper-input-error is referenced by an `aria-describedby` attribute.