### PR TITLE
Add properties to allow setting the internal input's ARIA role and aria-haspopup attribute.

### DIFF
--- a/paper-input.js
+++ b/paper-input.js
@@ -168,7 +168,7 @@ Polymer({
 
       <!-- Need to bind maxlength so that the paper-input-char-counter works correctly -->
       <iron-input bind-value="{{value}}" slot="input" class="input-element" id$="[[_inputId]]" maxlength$="[[maxlength]]" allowed-pattern="[[allowedPattern]]" invalid="{{invalid}}" validator="[[validator]]">
-        <input aria-labelledby$="[[_ariaLabelledBy]]" aria-describedby$="[[_ariaDescribedBy]]" disabled$="[[disabled]]" title$="[[title]]" type$="[[type]]" pattern$="[[pattern]]" required$="[[required]]" autocomplete$="[[autocomplete]]" autofocus$="[[autofocus]]" inputmode$="[[inputmode]]" minlength$="[[minlength]]" maxlength$="[[maxlength]]" min$="[[min]]" max$="[[max]]" step$="[[step]]" name$="[[name]]" placeholder$="[[placeholder]]" readonly$="[[readonly]]" list$="[[list]]" size$="[[size]]" autocapitalize$="[[autocapitalize]]" autocorrect$="[[autocorrect]]" on-change="_onChange" tabindex$="[[tabIndex]]" autosave$="[[autosave]]" results$="[[results]]" accept$="[[accept]]" multiple$="[[multiple]]">
+        <input aria-labelledby$="[[_ariaLabelledBy]]" aria-describedby$="[[_ariaDescribedBy]]" disabled$="[[disabled]]" title$="[[title]]" type$="[[type]]" pattern$="[[pattern]]" required$="[[required]]" autocomplete$="[[autocomplete]]" autofocus$="[[autofocus]]" inputmode$="[[inputmode]]" minlength$="[[minlength]]" maxlength$="[[maxlength]]" min$="[[min]]" max$="[[max]]" step$="[[step]]" name$="[[name]]" placeholder$="[[placeholder]]" readonly$="[[readonly]]" list$="[[list]]" size$="[[size]]" autocapitalize$="[[autocapitalize]]" autocorrect$="[[autocorrect]]" on-change="_onChange" tabindex$="[[tabIndex]]" autosave$="[[autosave]]" results$="[[results]]" accept$="[[accept]]" multiple$="[[multiple]]" role$="[[inputRole]]" aria-haspopup$="[[inputAriaHaspopup]]">
       </iron-input>
 
       <slot name="suffix" slot="suffix"></slot>
@@ -190,7 +190,17 @@ Polymer({
     value: {
       // Required for the correct TypeScript type-generation
       type: String
-    }
+    },
+
+    inputRole: {
+      type: String,
+      value: undefined,
+    },
+
+    inputAriaHaspopup: {
+      type: String,
+      value: undefined,
+    },
   },
 
   /**


### PR DESCRIPTION
This is part of PolymerElements/paper-dropdown-menu#317, which needs to set these to be able to continue using paper-input for the sake of styling but also allow paper-input's wrapped input to act as the focusable element while being read by screen readers as a button rather than a text input.