### PR TITLE
Update autofocus property to be non-nullable

### DIFF
--- a/paper-input-behavior.js
+++ b/paper-input-behavior.js
@@ -170,6 +170,8 @@ export const PaperInputBehaviorImpl = {
      * If you're using PaperInputBehavior to implement your own paper-input-like
      * element, bind this to the `<input is="iron-input">`'s `autofocus`
      * property.
+     *
+     * @type {boolean}
      */
     autofocus: {type: Boolean, observer: '_autofocusChanged'},
 

--- a/paper-input-behavior.js
+++ b/paper-input-behavior.js
@@ -171,7 +171,7 @@ export const PaperInputBehaviorImpl = {
      * element, bind this to the `<input is="iron-input">`'s `autofocus`
      * property.
      *
-     * @type {boolean}
+     * @type {!boolean}
      */
     autofocus: {type: Boolean, observer: '_autofocusChanged'},
 


### PR DESCRIPTION
In TypeScript 3.8 a new property `autofocus` was introduced on `HTMLElement`. When a component like [`gold-phone-input`](https://github.com/PolymerElements/gold-phone-input/blob/master/gold-phone-input.js) extends both this behavior and `HTMLElement` the `autofocus` properties now conflict. This change marks `autofocus` as non-nullable to align with TypeScript's `HTMLElement`.

Here's a playground link demoing the issue: http://www.typescriptlang.org/play/#code/JYOwLgpgTgZghgYwgAgJIgA4FcwCEIAWcAbsAPZTIDeAUMvcnDmTGQlgM4BcyARmWQA2EOCGQAfZCCyDBE5FhAATCDFAQlAbhoBfGjVCRYiFAAUCZEBHTYwyCAA9Iyjmkw58RUhQA0yABIAKgCyADIAosIAthDg1HQMujRAA

To see past behavior set the version to 3.7.5, and the current by setting the version to 3.8.3.